### PR TITLE
add function imports for fixing os.real_path, os.link and os.symlink on TCC32

### DIFF
--- a/lib/kernel32.def
+++ b/lib/kernel32.def
@@ -73,6 +73,8 @@ CreateFileA
 CreateFileMappingA
 CreateFileMappingW
 CreateFileW
+CreateHardLinkA
+CreateHardLinkW
 CreateIoCompletionPort
 CreateKernelThread
 CreateMailslotA
@@ -88,6 +90,7 @@ CreateRemoteThread
 CreateSemaphoreA
 CreateSemaphoreW
 CreateSocketHandle
+CreateSymbolicLinkA
 CreateSymbolicLinkW
 CreateTapePartition
 CreateThread
@@ -271,7 +274,7 @@ GetFileInformationByHandle
 GetFileSize
 GetFileTime
 GetFileType
-GetFinalPathNameByHandle
+GetFinalPathNameByHandleA
 GetFinalPathNameByHandleW
 GetFullPathNameA
 GetFullPathNameW


### PR DESCRIPTION
This PR adds some API imports which are needed to use Win32 API functions for `os.real_path()`, `os.link()` and `os.symlink()` on TCC32.
Another PR, which implements the functions, is linked to this one.