### PR TITLE
ci: fix push trigger left pointing at the merged-away PR branch

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,7 +2,7 @@ name: build and test (windows-amd64)
 
 on:
   push:
-    branches: [bump-current-tinycc]
+    branches: [thirdparty-windows-amd64]
   pull_request:
     branches: [thirdparty-windows-amd64]
   workflow_dispatch: {}


### PR DESCRIPTION
Small follow-up to #67. As merged, the workflow's `push:` trigger was
still scoped to `bump-current-tinycc` (the feature branch #67 was
developed on, which no longer matters now that it's merged). Since the
workflow now lives permanently on `thirdparty-windows-amd64`, a future
direct push to that branch wouldn't have triggered it - only opening
or updating a PR against it would have. This points the push trigger
at the branch it actually lives on.

Separately, worth noting: the workflow's checkout step still points at
my fork (`quaesitor-scientiam/v`) for `thirdparty/tccbin_tests`, since
[vlang/v#27924](https://github.com/vlang/v/pull/27924) (the shared
conformance test suite) hasn't merged yet - already flagged as a TODO
in that step's comment. Not fixing that here since it depends on that
PR's fate; happy to send a follow-up once/if it lands.