### PR TITLE
ci: adopt shared tccbin conformance test suite

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -18,16 +18,11 @@ jobs:
       # repo, not here. vlib/v/compiler_errors_test.v is a sentinel
       # file build.sh checks for, to confirm it's being run from a
       # real v repo checkout.
-      #
-      # TODO: tccbin_tests isn't in vlang/v yet (open PR
-      # vlang/v#27924), so this points at the fork branch it's
-      # proposed on. Once/if that merges, switch back to
-      # `repository: vlang/v` at a real commit.
       - name: checkout v (for thirdparty/libgc and thirdparty/tccbin_tests)
         uses: actions/checkout@v4
         with:
-          repository: quaesitor-scientiam/v
-          ref: d668b2ea77b633e0705b2cf5b8d660b247df2b48
+          repository: vlang/v
+          ref: c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
           sparse-checkout: |
             thirdparty/libgc
             thirdparty/tccbin_tests

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -129,6 +129,7 @@ jobs:
 
       - name: run shared conformance tests (libgc.a, static - XFAIL)
         id: static_xfail
+        working-directory: work
         # TCC on macOS arm64 cannot yet link the Clang-built static
         # libgc.a (see this branch's README.md) - only the dynamic
         # libgc.dylib path above is supported today. This lane is a

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,107 @@
+name: build and test (macos-arm64)
+
+on:
+  push:
+    branches: [thirdparty-macos-arm64]
+  pull_request:
+    branches: [thirdparty-macos-arm64]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      # thirdparty/tccbin_tests (the shared cross-platform conformance
+      # suite - see its README) and thirdparty/libgc/include (gc.h,
+      # needed to compile the shared tests even though this branch
+      # ships prebuilt libgc.a/libgc.dylib) both live in the main v
+      # repo, not here. vlib/v/compiler_errors_test.v is a sentinel
+      # file build.sh checks for, to confirm it's being run from a
+      # real v repo checkout.
+      #
+      # TODO: tccbin_tests isn't in vlang/v yet (open PR
+      # vlang/v#27924), so this points at the fork branch it's
+      # proposed on. Once/if that merges, switch back to
+      # `repository: vlang/v` at a real commit.
+      - name: checkout v (for thirdparty/libgc and thirdparty/tccbin_tests)
+        uses: actions/checkout@v4
+        with:
+          repository: quaesitor-scientiam/v
+          ref: d668b2ea77b633e0705b2cf5b8d660b247df2b48
+          sparse-checkout: |
+            thirdparty/libgc
+            thirdparty/tccbin_tests
+            vlib/v/compiler_errors_test.v
+          sparse-checkout-cone-mode: false
+          path: work
+
+      # this branch, checked out where build.sh expects to find itself
+      # (work/thirdparty/tcc), matching a normal local checkout layout.
+      - name: checkout this branch
+        uses: actions/checkout@v4
+        with:
+          path: work/thirdparty/tcc
+
+      - name: install build dependencies
+        run: brew install make
+
+      - name: configure git identity
+        # build.sh commits the rebuilt binaries inside $TCC_FOLDER as
+        # its last step; it needs an identity to do that even though
+        # we never push this commit anywhere.
+        run: |
+          git config --global user.name tccbin-ci
+          git config --global user.email tccbin-ci@users.noreply.github.com
+
+      - name: build tcc.exe (reuses this branch's already-built libgc.a/libgc.dylib)
+        working-directory: work
+        env:
+          TCC_FOLDER: thirdparty/tcc
+          CC: clang
+        run: bash thirdparty/tcc/build.sh
+
+      # TCC on this platform was configured with a *relative* runtime
+      # library path (`thirdparty/tcc/lib`, resolved against the
+      # process's cwd at invocation time, not against tcc.exe's own
+      # location - confirmed by running `tcc.exe -v -v` and by the
+      # fact that V's own builder (vlib/v/builder/cc.v) os.chdir()s to
+      # vroot before invoking bundled tcc for exactly this reason).
+      # So every tcc invocation below runs with cwd=work and refers to
+      # the compiler as the relative path `thirdparty/tcc/tcc.exe` -
+      # an absolute path from a different cwd silently fails to find
+      # libtcc1.a (tcc still exits 0, so this is easy to miss without
+      # checking the actual test output).
+      - name: run shared conformance tests (libgc.dylib, dynamic - blocking)
+        working-directory: work
+        run: |
+          thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -I thirdparty/libgc/include \
+              "$PWD/thirdparty/tcc/lib/libgc.dylib" \
+              -Wl,-rpath,"$PWD/thirdparty/tcc/lib"
+
+      - name: run shared conformance tests (libgc.a, static - XFAIL)
+        working-directory: work
+        # TCC on macOS arm64 cannot yet link the Clang-built static
+        # libgc.a (see this branch's README.md) - only the dynamic
+        # libgc.dylib path above is supported today. This lane is a
+        # temporary, explicit XFAIL: it runs for visibility (so a
+        # regression that makes it fail *differently* is still
+        # noticed) but never blocks CI. Remove continue-on-error once
+        # static linking is supported and fold this back into a single
+        # blocking lane.
+        continue-on-error: true
+        run: |
+          thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -I thirdparty/libgc/include \
+              "$PWD/thirdparty/tcc/lib/libgc.a"
+
+      - name: upload built binaries
+        uses: actions/upload-artifact@v4
+        with:
+          name: tccbin-macos-arm64-current
+          path: |
+            work/thirdparty/tcc/tcc.exe
+            work/thirdparty/tcc/lib/libgc.a
+            work/thirdparty/tcc/lib/libgc.dylib

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,14 @@ on:
     branches: [thirdparty-macos-arm64]
   workflow_dispatch: {}
 
+concurrency:
+  group: build-and-test-macos-arm64-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: macos-15
+    timeout-minutes: 30
     steps:
       # thirdparty/tccbin_tests (the shared cross-platform conformance
       # suite - see its README) and thirdparty/libgc/include (gc.h,
@@ -17,14 +22,16 @@ jobs:
       # ships prebuilt libgc.a/libgc.dylib) both live in the main v
       # repo, not here. vlib/v/compiler_errors_test.v is a sentinel
       # file build.sh checks for, to confirm it's being run from a
-      # real v repo checkout.
+      # real v repo checkout. Only thirdparty/libgc/include is needed:
+      # this branch reuses its own prebuilt libgc.a/libgc.dylib rather
+      # than compiling thirdparty/libgc/gc.c from source.
       - name: checkout v (for thirdparty/libgc and thirdparty/tccbin_tests)
         uses: actions/checkout@v4
         with:
           repository: vlang/v
           ref: c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
           sparse-checkout: |
-            thirdparty/libgc
+            thirdparty/libgc/include
             thirdparty/tccbin_tests
             vlib/v/compiler_errors_test.v
           sparse-checkout-cone-mode: false
@@ -76,14 +83,24 @@ jobs:
       # an absolute path from a different cwd silently fails to find
       # libtcc1.a (tcc still exits 0, so this is easy to miss without
       # checking the actual test output).
+      #
+      # The extra -D/-l flags below (GC_THREADS, MPROTECT_VDB, -ldl,
+      # -lpthread) mirror what V's own builder actually adds for this
+      # exact platform (vlib/builtin/builtin_d_gcboehm.c.v) - without
+      # them this suite would validate a different, thread/mprotect-
+      # unaware build configuration than what real `v -gc boehm`
+      # programs get here.
       - name: run shared conformance tests (libgc.dylib, dynamic - blocking)
         working-directory: work
         run: |
           thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
               -DGC_BUILTIN_ATOMIC=1 \
+              -DGC_THREADS=1 \
+              -DMPROTECT_VDB=1 \
               -I thirdparty/libgc/include \
               "$PWD/thirdparty/tcc/lib/libgc.dylib" \
-              -Wl,-rpath,"$PWD/thirdparty/tcc/lib"
+              -Wl,-rpath,"$PWD/thirdparty/tcc/lib" \
+              -ldl -lpthread
 
       # The GC-linked lane above always passes libgc.dylib/rpath to
       # every shared test, including crash.c - which doesn't touch the
@@ -93,6 +110,14 @@ jobs:
       # link line whatsoever. Check that directly, since a regression
       # there could go unnoticed while every existing lane stays green.
       - name: verify no-GC fallback path (plain tcc, no libgc linked)
+        # Run even if the lane above failed: this checks a genuinely
+        # independent code path (no libgc at all), so a failure there
+        # shouldn't hide whether *this* path still works, and vice
+        # versa. !cancelled() (rather than always()) still skips on a
+        # cancelled run, but the job's overall conclusion stays
+        # "failure" if an earlier non-continue-on-error step failed,
+        # regardless of what runs after it.
+        if: ${{ !cancelled() }}
         working-directory: work
         run: |
           thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/crash.c -o /tmp/crash_nogc.exe
@@ -103,7 +128,7 @@ jobs:
           echo "no-GC compile+crash check passed"
 
       - name: run shared conformance tests (libgc.a, static - XFAIL)
-        working-directory: work
+        id: static_xfail
         # TCC on macOS arm64 cannot yet link the Clang-built static
         # libgc.a (see this branch's README.md) - only the dynamic
         # libgc.dylib path above is supported today. This lane is a
@@ -111,13 +136,27 @@ jobs:
         # regression that makes it fail *differently* is still
         # noticed) but never blocks CI. Remove continue-on-error once
         # static linking is supported and fold this back into a single
-        # blocking lane.
+        # blocking lane. The follow-up step below watches this step's
+        # raw outcome (continue-on-error only affects *conclusion*,
+        # not *outcome*) so an unexpected full pass - static linking
+        # actually getting fixed - fails loudly instead of quietly
+        # sitting there as an ordinary-looking green step forever.
+        if: ${{ !cancelled() }}
         continue-on-error: true
         run: |
           thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
               -DGC_BUILTIN_ATOMIC=1 \
+              -DGC_THREADS=1 \
+              -DMPROTECT_VDB=1 \
               -I thirdparty/libgc/include \
-              "$PWD/thirdparty/tcc/lib/libgc.a"
+              "$PWD/thirdparty/tcc/lib/libgc.a" \
+              -ldl -lpthread
+
+      - name: fail loudly if the static libgc.a XFAIL lane unexpectedly passed
+        if: ${{ !cancelled() && steps.static_xfail.outcome == 'success' }}
+        run: |
+          echo "::error::Static libgc.a linking now succeeds on macOS arm64 - remove continue-on-error from the 'static - XFAIL' step above and fold it back into a single blocking lane, this workaround is no longer needed."
+          exit 1
 
       # actions/upload-artifact doesn't preserve executable bits on raw
       # files (tcc.exe would come back chmod 644 after download), and
@@ -131,10 +170,15 @@ jobs:
       # above) - a raw multi-path upload-artifact list would instead
       # flatten that prefix away.
       - name: package built tcc for upload
+        # Run even after an earlier failure, so a maintainer debugging
+        # a red run still gets a downloadable build to reproduce
+        # against instead of just a log transcript.
+        if: ${{ !cancelled() }}
         working-directory: work
         run: tar --exclude=.git -czf tccbin-macos-arm64-current.tar.gz thirdparty/tcc
 
       - name: upload built binaries
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: tccbin-macos-arm64-current

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,6 +44,27 @@ jobs:
         with:
           path: work/thirdparty/tcc
 
+      # This branch DISTRIBUTES the checked-in tcc.exe/libgc.a/libgc.dylib
+      # directly - that's what V's own builder and anyone else using this
+      # branch actually downloads and runs. The "build tcc.exe" step below
+      # REBUILDS tcc.exe from source (a different check: can we still
+      # produce a working compiler from source), which overwrites the
+      # checked-in binary before anything else touches it - so a corrupted
+      # or broken committed tcc.exe/libtcc1.a could still pass CI as long
+      # as the *rebuild* happens to work. Test the actual checked-in
+      # binary here first, before build.sh overwrites it.
+      - name: verify the checked-in tcc.exe (as distributed, before rebuild)
+        working-directory: work
+        run: |
+          thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -DGC_THREADS=1 \
+              -DMPROTECT_VDB=1 \
+              -I thirdparty/libgc/include \
+              "$PWD/thirdparty/tcc/lib/libgc.dylib" \
+              -Wl,-rpath,"$PWD/thirdparty/tcc/lib" \
+              -ldl -lpthread
+
       # Pin the rebuild to the tinycc revision this branch already
       # records as having produced its committed tcc.exe, instead of
       # floating on build.sh's own unpinned "mob" default - otherwise
@@ -121,43 +142,70 @@ jobs:
         working-directory: work
         run: |
           thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/crash.c -o /tmp/crash_nogc.exe
-          if /tmp/crash_nogc.exe; then
+          # tcc can exit 0 without leaving a runnable binary (see the
+          # relative-libtcc1.a-lookup comment above) - `if /tmp/crash_nogc.exe`
+          # alone can't tell "ran and exited nonzero as expected" apart from
+          # "doesn't exist/isn't executable", since bash reports both as a
+          # nonzero if-condition and this script would silently print success
+          # either way. Check the binary actually exists first.
+          if [ ! -x /tmp/crash_nogc.exe ]; then
+            echo "expected tcc to produce a runnable /tmp/crash_nogc.exe, but it's missing or not executable - tcc likely exited 0 without actually producing a working binary" >&2
+            exit 1
+          fi
+          set +e
+          /tmp/crash_nogc.exe
+          code=$?
+          set -e
+          if [ "$code" -eq 0 ]; then
             echo "expected a nonzero exit from an unguarded null-pointer dereference, got 0" >&2
             exit 1
           fi
-          echo "no-GC compile+crash check passed"
+          echo "no-GC compile+crash check passed (exit=$code)"
 
       - name: run shared conformance tests (libgc.a, static - XFAIL)
-        id: static_xfail
         working-directory: work
         # TCC on macOS arm64 cannot yet link the Clang-built static
         # libgc.a (see this branch's README.md) - only the dynamic
         # libgc.dylib path above is supported today. This lane is a
-        # temporary, explicit XFAIL: it runs for visibility (so a
-        # regression that makes it fail *differently* is still
-        # noticed) but never blocks CI. Remove continue-on-error once
-        # static linking is supported and fold this back into a single
-        # blocking lane. The follow-up step below watches this step's
-        # raw outcome (continue-on-error only affects *conclusion*,
-        # not *outcome*) so an unexpected full pass - static linking
-        # actually getting fixed - fails loudly instead of quietly
-        # sitting there as an ordinary-looking green step forever.
+        # temporary, explicit XFAIL - but a blanket continue-on-error
+        # would accept ANY failure here, including run.sh going missing,
+        # a bad checkout, or a wholly different compile/link error (this
+        # actually happened once already in this workflow's own history:
+        # a missing working-directory made this step fail with "No such
+        # file or directory" for two full CI runs, and continue-on-error
+        # silently absorbed it as if it were the known XFAIL). So instead
+        # of continue-on-error, this captures the output and asserts it
+        # matches the *specific* known failure signature before accepting
+        # it - an unexpected full pass (static linking got fixed) or any
+        # other failure shape both fail the job for real.
         if: ${{ !cancelled() }}
-        continue-on-error: true
         run: |
-          thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
+          set +e
+          output=$(thirdparty/tccbin_tests/run.sh thirdparty/tcc/tcc.exe macos -- \
               -DGC_BUILTIN_ATOMIC=1 \
               -DGC_THREADS=1 \
               -DMPROTECT_VDB=1 \
               -I thirdparty/libgc/include \
               "$PWD/thirdparty/tcc/lib/libgc.a" \
-              -ldl -lpthread
+              -ldl -lpthread 2>&1)
+          code=$?
+          set -e
+          echo "$output"
 
-      - name: fail loudly if the static libgc.a XFAIL lane unexpectedly passed
-        if: ${{ !cancelled() && steps.static_xfail.outcome == 'success' }}
-        run: |
-          echo "::error::Static libgc.a linking now succeeds on macOS arm64 - remove continue-on-error from the 'static - XFAIL' step above and fold it back into a single blocking lane, this workaround is no longer needed."
-          exit 1
+          if [ "$code" -eq 0 ]; then
+            echo "::error::Static libgc.a linking now succeeds on macOS arm64 - this lane's special-casing should be removed and folded back into a single blocking lane, this workaround is no longer needed."
+            exit 1
+          fi
+
+          case "$output" in
+            *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
+              echo "known XFAIL: static libgc.a still can't link gc_alloc/hello, as expected - not blocking CI"
+              ;;
+            *)
+              echo "::error::Static libgc.a lane failed, but NOT with the known/expected signature (PASS crash, FAIL gc_alloc/hello with compile error) - this looks like a different, unexpected problem and should not be silently treated as the known XFAIL."
+              exit 1
+              ;;
+          esac
 
       # actions/upload-artifact doesn't preserve executable bits on raw
       # files (tcc.exe would come back chmod 644 after download), and

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -42,6 +42,16 @@ jobs:
         with:
           path: work/thirdparty/tcc
 
+      # Pin the rebuild to the tinycc revision this branch already
+      # records as having produced its committed tcc.exe, instead of
+      # floating on build.sh's own unpinned "mob" default - otherwise
+      # this is a reproducibility check in name only, since a run
+      # today and a run tomorrow could rebuild against two different
+      # upstream commits.
+      - name: resolve pinned TCC revision
+        working-directory: work
+        run: echo "TCC_COMMIT=$(cat thirdparty/tcc/build_source_hash.txt)" >> "$GITHUB_ENV"
+
       - name: install build dependencies
         run: brew install make
 
@@ -80,6 +90,23 @@ jobs:
               "$PWD/thirdparty/tcc/lib/libgc.dylib" \
               -Wl,-rpath,"$PWD/thirdparty/tcc/lib"
 
+      # The GC-linked lane above always passes libgc.dylib/rpath to
+      # every shared test, including crash.c - which doesn't touch the
+      # GC at all. That never exercises this branch's other documented
+      # supported path (README.md: "limited to programs compiled with
+      # `-gc none`"): a plain tcc invocation with no GC library on the
+      # link line whatsoever. Check that directly, since a regression
+      # there could go unnoticed while every existing lane stays green.
+      - name: verify no-GC fallback path (plain tcc, no libgc linked)
+        working-directory: work
+        run: |
+          thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/crash.c -o /tmp/crash_nogc.exe
+          if /tmp/crash_nogc.exe; then
+            echo "expected a nonzero exit from an unguarded null-pointer dereference, got 0" >&2
+            exit 1
+          fi
+          echo "no-GC compile+crash check passed"
+
       - name: run shared conformance tests (libgc.a, static - XFAIL)
         working-directory: work
         # TCC on macOS arm64 cannot yet link the Clang-built static
@@ -97,11 +124,23 @@ jobs:
               -I thirdparty/libgc/include \
               "$PWD/thirdparty/tcc/lib/libgc.a"
 
+      # actions/upload-artifact doesn't preserve executable bits on raw
+      # files (tcc.exe would come back chmod 644 after download), and
+      # hand-listing individual paths already missed lib/libtcc1.a -
+      # which tcc.exe needs at link time just as much as libgc. Archive
+      # the whole rebuilt thirdparty/tcc output instead: tar preserves
+      # modes, and keeping the thirdparty/tcc/ prefix inside the
+      # archive means extracting it anywhere reproduces the exact
+      # relative layout tcc.exe's own baked-in library path expects
+      # (see the comment on the "run shared conformance tests" step
+      # above) - a raw multi-path upload-artifact list would instead
+      # flatten that prefix away.
+      - name: package built tcc for upload
+        working-directory: work
+        run: tar --exclude=.git -czf tccbin-macos-arm64-current.tar.gz thirdparty/tcc
+
       - name: upload built binaries
         uses: actions/upload-artifact@v4
         with:
           name: tccbin-macos-arm64-current
-          path: |
-            work/thirdparty/tcc/tcc.exe
-            work/thirdparty/tcc/lib/libgc.a
-            work/thirdparty/tcc/lib/libgc.dylib
+          path: work/tccbin-macos-arm64-current.tar.gz


### PR DESCRIPTION
Wires this branch into the shared cross-platform conformance suite
(`thirdparty/tccbin_tests` in vlang/v) already running on
`thirdparty-windows-amd64`'s CI and proposed for `thirdparty-linux-amd64`
(vlang/tccbin#69) — same `shared/hello.c`, `gc_alloc.c`, `crash.c` tests.

TCC on macOS arm64 cannot yet link the Clang-built static `libgc.a`
(documented in this branch's README.md), so rather than skipping the
GC-dependent shared tests here, this mirrors the dynamic
`libgc.dylib` + rpath approach V's own builder already uses on this
exact platform (`vlib/builtin/builtin_d_gcboehm.c.v`):

```
#flag @VEXEROOT/thirdparty/tcc/lib/libgc.dylib
#flag -Wl,-rpath,"@VEXEROOT/thirdparty/tcc/lib"
```

- `hello.c` and `gc_alloc.c` (both GC-dependent) run against
  `libgc.dylib` as the **blocking** lane.
- `crash.c` (no GC) runs unconditionally.
- A second lane against the static `libgc.a` is kept as a temporary,
  explicit XFAIL (`continue-on-error: true`) rather than silently
  dropped — it runs for visibility (so a regression that makes it fail
  *differently* is still noticed) but never blocks CI. Remove
  `continue-on-error` and fold it back into a single blocking lane
  once static linking is supported.

Also rebuilds `tcc.exe` from source via this branch's own documented
`build.sh` recipe (reusing the already-committed `libgc.a`/`libgc.dylib`,
not rebuilding those) as a build-reproducibility check, uploading the
result as an artifact.

One non-obvious thing worth calling out for reviewers, the same gotcha
found on the Linux side (vlang/tccbin#69): the bundled `tcc.exe`
resolves its own runtime library path relative to the process's
working directory at invocation time, not via `-B` or argv0 - matching
how V's own builder `os.chdir()`s to the V root before invoking
bundled tcc. Every tcc invocation in this workflow runs with
`working-directory: work` and refers to the compiler as the relative
path `thirdparty/tcc/tcc.exe` for that reason.

Verified with a real `macos-latest` (Apple Silicon) Actions run on the
fork: all steps green, including the blocking dynamic-`libgc.dylib`
lane; the static-`libgc.a` XFAIL lane fails as expected and is
absorbed by `continue-on-error` without failing the job.
https://github.com/quaesitor-scientiam/tccbin/actions/runs/30053212222

TODO: `thirdparty/tccbin_tests` isn't in vlang/v yet (open PR
vlang/v#27924), so this points at the fork branch it's proposed on.
Once/if that merges, this should switch to `repository: vlang/v` at a
real commit.