### PR TITLE
ci: point shared conformance suite checkout at vlang/v

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,15 +14,11 @@ jobs:
       # thirdparty/libgc/include (headers) and thirdparty/tccbin_tests (the
       # shared cross-platform conformance suite - see its README) both live
       # in the main v repo, not here.
-      #
-      # TODO: tccbin_tests isn't in vlang/v yet (open PR), so this points at
-      # the fork branch it's proposed on. Once/if that merges, switch back
-      # to `repository: vlang/v` at a real commit.
       - name: checkout v (for thirdparty/libgc and thirdparty/tccbin_tests)
         uses: actions/checkout@v4
         with:
-          repository: quaesitor-scientiam/v
-          ref: d668b2ea77b633e0705b2cf5b8d660b247df2b48
+          repository: vlang/v
+          ref: c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
           sparse-checkout: |
             thirdparty/libgc
             thirdparty/tccbin_tests


### PR DESCRIPTION
vlang/v#27924 (the shared thirdparty/tccbin_tests suite) has merged
(c82d3f08271e9324d6fb8de3c251e9c0e1a9154b), so the CI workflow here no
longer needs to point at the fork branch it was proposed on
(vlang/tccbin#69's TODO). Switches the checkout step to
`repository: vlang/v` at that commit.

No behavior change otherwise.