### PR TITLE
ci: adopt shared tccbin conformance test suite (freebsd-amd64)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,6 +45,16 @@ jobs:
 
           chmod +x thirdparty/tcc/tcc.exe
 
+          # TEMPORARY diagnostic: run.sh swallows compile stderr, so on
+          # first failure here we can't see *why* linking failed. Show
+          # it directly before running the real suite.
+          thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
+              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
+              -I "$PWD/vsrc/thirdparty/libgc/include" \
+              "$PWD/thirdparty/tcc/lib/libgc.a" \
+              -lpthread \
+              -o /tmp/hello_diag || true
+
           # The bundled tcc.exe resolves its own crt/libtcc1.a via a path
           # relative to the process's working directory (confirmed on
           # linux-amd64/macos-arm64's CI) - thirdparty/tcc/tcc.exe is

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,6 +17,25 @@ jobs:
       # directly inside the VM (rather than actions/checkout on the
       # runner + sync_files) mirrors that proven-working pattern instead
       # of relying on an unverified file-permission-preserving sync.
+      # For a pull_request event, clone the PR's own head repo+ref
+      # (so a PR that updates tcc.exe/libgc.a is actually tested)
+      # instead of the unrelated target branch's current tip - a
+      # hardcoded `git clone --branch thirdparty-freebsd-amd64
+      # .../vlang/tccbin.git` would silently test only the
+      # already-merged target branch regardless of what the PR
+      # proposes. push/workflow_dispatch have no PR context, so they
+      # fall back to whatever ref actually triggered the run.
+      - name: resolve what to clone
+        id: clone_target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "url=${{ github.event.pull_request.head.repo.clone_url }}" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=https://github.com/vlang/tccbin.git" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Start freebsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0
         with:
@@ -25,6 +44,10 @@ jobs:
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
+          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
+        env:
+          TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
+          TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
 
       - name: fetch shared conformance suite and this branch's binaries
         shell: cpa.sh {0}
@@ -32,8 +55,8 @@ jobs:
           set -eu
           sudo pkg install -y bash git
 
-          git clone --branch thirdparty-freebsd-amd64 --depth=1 \
-            https://github.com/vlang/tccbin.git thirdparty/tcc
+          git clone --branch "$TCCBIN_CLONE_REF" --depth=1 \
+            "$TCCBIN_CLONE_URL" thirdparty/tcc
 
           # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
           # (the shared cross-platform conformance suite) both live in
@@ -66,11 +89,25 @@ jobs:
           set -eu
           thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/crash.c \
               -o /tmp/crash_nogc
-          if /tmp/crash_nogc; then
-            echo "expected a nonzero exit from an unguarded null-pointer dereference, got 0" >&2
+
+          set +e
+          /tmp/crash_nogc
+          code=$?
+          set -e
+
+          # Any nonzero exit isn't enough: an exec-format error, a
+          # missing dynamic loader, or an unrelated miscompilation that
+          # just exit(1)s would also satisfy that and silently mask a
+          # real regression, since the GC-backed suite below is
+          # non-blocking. crash.c's null-pointer dereference is
+          # expected to be killed by SIGSEGV specifically, which a
+          # POSIX shell reports as exit code 128+11=139 - verify that
+          # exact signal-terminated signature, not just "nonzero".
+          if [ "$code" -ne 139 ]; then
+            echo "expected exit 139 (killed by SIGSEGV) from an unguarded null-pointer dereference, got $code" >&2
             exit 1
           fi
-          echo "no-GC compile+crash check passed"
+          echo "no-GC compile+crash check passed (killed by SIGSEGV as expected)"
 
       - name: run shared conformance tests (libgc.a - XFAIL until the etext/end tcc fix ships)
         shell: cpa.sh {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,21 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # For a pull_request event, clone the PR's own head repo+ref (so a
+    # PR that updates tcc.exe/libgc.a is actually tested) instead of
+    # the unrelated target branch's current tip - a hardcoded
+    # `git clone --branch thirdparty-freebsd-amd64 .../vlang/tccbin.git`
+    # would silently test only the already-merged target branch
+    # regardless of what the PR proposes. push/workflow_dispatch have
+    # no PR context, so they fall back to whatever ref triggered the
+    # run. Set at job level (matching update_tccbin.yml's own working
+    # BSD job env, which only ever references github.*/secrets.*, never
+    # steps.* - step-level env on the "Start VM" step was tried first
+    # and empirically did NOT get forwarded into the VM by
+    # environment_variables, unlike this job-level placement).
+    env:
+      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
+      TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
     steps:
       # cross-platform-actions/action boots a real FreeBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
@@ -17,18 +32,6 @@ jobs:
       # directly inside the VM (rather than actions/checkout on the
       # runner + sync_files) mirrors that proven-working pattern instead
       # of relying on an unverified file-permission-preserving sync.
-      #
-      # For a pull_request event, clone the PR's own head repo+ref (so
-      # a PR that updates tcc.exe/libgc.a is actually tested) instead
-      # of the unrelated target branch's current tip - a hardcoded
-      # `git clone --branch thirdparty-freebsd-amd64 .../vlang/tccbin.git`
-      # would silently test only the already-merged target branch
-      # regardless of what the PR proposes. push/workflow_dispatch have
-      # no PR context, so they fall back to whatever ref triggered the
-      # run. Computed inline here (not a separate step + job-level env)
-      # because job-level env can't reference the steps context at all -
-      # that's a schema violation that fails the whole workflow file,
-      # not just this expression.
       - name: Start freebsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0
         with:
@@ -38,9 +41,6 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
-        env:
-          TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
-          TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: fetch shared conformance suite and this branch's binaries
         shell: cpa.sh {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -76,21 +76,15 @@ jobs:
   verify-etext-fix:
     runs-on: ubuntu-latest
     steps:
-      - name: Start freebsd-amd64 VM
-        uses: cross-platform-actions/action@v1.3.0
-        with:
-          operating_system: freebsd
-          version: '15.1'
-          memory: 4G
-          shell: sh
-          sync_files: runner-to-vm
-
-      - name: build patched tcc and test against bundled libgc.a
-        shell: cpa.sh {0}
+      # repo.or.cz (tinycc's canonical host - no GitHub mirror exists)
+      # resets connections from inside the FreeBSD VM every time
+      # (reproduced twice) - cloning + patching here on the runner instead
+      # avoids that network path entirely; sync_files: runner-to-vm below
+      # carries the already-patched source into the VM via rsync (which
+      # preserves permissions) before each cpa.sh step runs.
+      - name: clone and patch tinycc on the runner
         run: |
           set -eu
-          sudo pkg install -y bash git gmake
-
           cat > etext_fix.patch <<'PATCHEOF'
           diff --git a/tccelf.c b/tccelf.c
           index 7e9758af..f9ae676c 100644
@@ -119,7 +113,22 @@ jobs:
           PATCHEOF
 
           git clone --quiet https://repo.or.cz/tinycc.git tinycc-src
-          git -C tinycc-src apply --verbose ../etext_fix.patch
+          git -C tinycc-src apply --verbose etext_fix.patch
+
+      - name: Start freebsd-amd64 VM
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: freebsd
+          version: '15.1'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+
+      - name: build patched tcc and test against bundled libgc.a
+        shell: cpa.sh {0}
+        run: |
+          set -eu
+          sudo pkg install -y bash git gmake
 
           cd tinycc-src
           ./configure --prefix=/tmp/tcc-patched

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,9 +10,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
-      TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
     steps:
       # cross-platform-actions/action boots a real FreeBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
@@ -20,25 +17,18 @@ jobs:
       # directly inside the VM (rather than actions/checkout on the
       # runner + sync_files) mirrors that proven-working pattern instead
       # of relying on an unverified file-permission-preserving sync.
-      # For a pull_request event, clone the PR's own head repo+ref
-      # (so a PR that updates tcc.exe/libgc.a is actually tested)
-      # instead of the unrelated target branch's current tip - a
-      # hardcoded `git clone --branch thirdparty-freebsd-amd64
-      # .../vlang/tccbin.git` would silently test only the
-      # already-merged target branch regardless of what the PR
-      # proposes. push/workflow_dispatch have no PR context, so they
-      # fall back to whatever ref actually triggered the run.
-      - name: resolve what to clone
-        id: clone_target
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "url=${{ github.event.pull_request.head.repo.clone_url }}" >> "$GITHUB_OUTPUT"
-            echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "url=https://github.com/vlang/tccbin.git" >> "$GITHUB_OUTPUT"
-            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          fi
-
+      #
+      # For a pull_request event, clone the PR's own head repo+ref (so
+      # a PR that updates tcc.exe/libgc.a is actually tested) instead
+      # of the unrelated target branch's current tip - a hardcoded
+      # `git clone --branch thirdparty-freebsd-amd64 .../vlang/tccbin.git`
+      # would silently test only the already-merged target branch
+      # regardless of what the PR proposes. push/workflow_dispatch have
+      # no PR context, so they fall back to whatever ref triggered the
+      # run. Computed inline here (not a separate step + job-level env)
+      # because job-level env can't reference the steps context at all -
+      # that's a schema violation that fails the whole workflow file,
+      # not just this expression.
       - name: Start freebsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0
         with:
@@ -48,6 +38,9 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
+        env:
+          TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
+          TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: fetch shared conformance suite and this branch's binaries
         shell: cpa.sh {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,7 +131,7 @@ jobs:
           sudo pkg install -y bash git gmake
 
           cd tinycc-src
-          ./configure --prefix=/tmp/tcc-patched
+          CC=cc ./configure --prefix=/tmp/tcc-patched --cc=cc
           gmake -j"$(sysctl -n hw.ncpu)"
           ./tcc --version
           cd ..

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -201,18 +201,22 @@ jobs:
           # regression isolated to the OTHER test (gc_alloc.c) hide
           # behind this same summary shape and pass unnoticed (Codex
           # pullrequestreview-4780815399 on vlang/tccbin#75).
+          set +e
           direct_err_hello=$(thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
               -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
               -I vsrc/thirdparty/libgc/include \
               thirdparty/tcc/lib/libgc.a \
               -lpthread \
-              -o /tmp/hello_xfail_probe 2>&1) || true
+              -o /tmp/hello_xfail_probe 2>&1)
+          direct_code_hello=$?
           direct_err_gc_alloc=$(thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/gc_alloc.c \
               -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
               -I vsrc/thirdparty/libgc/include \
               thirdparty/tcc/lib/libgc.a \
               -lpthread \
-              -o /tmp/gc_alloc_xfail_probe 2>&1) || true
+              -o /tmp/gc_alloc_xfail_probe 2>&1)
+          direct_code_gc_alloc=$?
+          set -e
 
           # Unlike macos-amd64's whole-archive-unparseable bug, this
           # FreeBSD bug is narrow: tcc's linker only ever fails to define
@@ -224,6 +228,20 @@ jobs:
           # additional regression rode along with the known bug (Codex
           # pullrequestreview-4780907186 on vlang/tccbin#75).
           is_known_etext_end() {
+            # $1 = captured stderr text, $2 = the probe's own exit code.
+            # A regression could make tcc print the expected etext/end
+            # diagnostic and then crash/abort rather than exiting
+            # cleanly with its normal compile-error status - the earlier
+            # `|| true` discarded that exit code entirely, so a shell
+            # "Segmentation fault" or similar abnormal termination
+            # alongside the expected text would still pass (Codex
+            # pullrequestreview-4781865117 on vlang/tccbin#75). A POSIX
+            # shell reports a signal-terminated process as exit code
+            # 128+signal; reject those instead of treating any nonzero
+            # exit as "the expected compile-error status".
+            if [ "$2" -gt 128 ]; then
+              return 1
+            fi
             case "$1" in
               *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*) ;;
               *) return 1 ;;
@@ -244,12 +262,12 @@ jobs:
 
           case "$output" in
             *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
-              if is_known_etext_end "$direct_err_hello" && is_known_etext_end "$direct_err_gc_alloc"; then
+              if is_known_etext_end "$direct_err_hello" "$direct_code_hello" && is_known_etext_end "$direct_err_gc_alloc" "$direct_code_gc_alloc"; then
                 echo "known XFAIL: etext/end still unresolved on FreeBSD tcc for both gc_alloc.c and hello.c, as expected - not blocking CI"
               else
-                echo "libgc.a lane failed with the known summary shape, but at least one of gc_alloc.c/hello.c's direct compile errors does NOT mention an unresolved etext/end symbol - this looks like a different, unexpected regression:" >&2
-                echo "hello.c: $direct_err_hello" >&2
-                echo "gc_alloc.c: $direct_err_gc_alloc" >&2
+                echo "libgc.a lane failed with the known summary shape, but at least one of gc_alloc.c/hello.c's direct compile errors does NOT mention an unresolved etext/end symbol (or exited abnormally) - this looks like a different, unexpected regression:" >&2
+                echo "hello.c: exit=$direct_code_hello: $direct_err_hello" >&2
+                echo "gc_alloc.c: exit=$direct_code_gc_alloc: $direct_err_gc_alloc" >&2
                 exit 1
               fi
               ;;

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,57 @@
+name: build and test (freebsd-amd64)
+
+on:
+  push:
+    branches: [thirdparty-freebsd-amd64]
+  pull_request:
+    branches: [thirdparty-freebsd-amd64]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # cross-platform-actions/action boots a real FreeBSD VM inside this
+      # Linux runner - the same action vlang/v's own update_tccbin.yml
+      # uses to rebuild this branch's binaries. Cloning both repos
+      # directly inside the VM (rather than actions/checkout on the
+      # runner + sync_files) mirrors that proven-working pattern instead
+      # of relying on an unverified file-permission-preserving sync.
+      - name: Start freebsd-amd64 VM
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: freebsd
+          version: '15.1'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+
+      - name: run shared conformance tests
+        shell: cpa.sh {0}
+        run: |
+          set -eu
+          sudo pkg install -y bash git
+
+          git clone --branch thirdparty-freebsd-amd64 --depth=1 \
+            https://github.com/vlang/tccbin.git thirdparty/tcc
+
+          # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
+          # (the shared cross-platform conformance suite) both live in
+          # the main v repo, not here.
+          git clone --filter=blob:none --no-checkout --depth=1 \
+            https://github.com/vlang/v.git vsrc
+          git -C vsrc sparse-checkout set --no-cone thirdparty/libgc thirdparty/tccbin_tests
+          git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+
+          chmod +x thirdparty/tcc/tcc.exe
+
+          # The bundled tcc.exe resolves its own crt/libtcc1.a via a path
+          # relative to the process's working directory (confirmed on
+          # linux-amd64/macos-arm64's CI) - thirdparty/tcc/tcc.exe is
+          # already correctly placed relative to $PWD here since we just
+          # cloned it there directly.
+          bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" freebsd -- \
+              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
+              -I "$PWD/vsrc/thirdparty/libgc/include" \
+              "$PWD/thirdparty/tcc/lib/libgc.a" \
+              -lpthread

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -113,7 +113,7 @@ jobs:
           PATCHEOF
 
           git clone --quiet https://repo.or.cz/tinycc.git tinycc-src
-          git -C tinycc-src apply --verbose etext_fix.patch
+          git -C tinycc-src apply --verbose "$PWD/etext_fix.patch"
 
       - name: Start freebsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,21 +10,26 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # For a pull_request event, clone the PR's own head repo+ref (so a
-    # PR that updates tcc.exe/libgc.a is actually tested) instead of
-    # the unrelated target branch's current tip - a hardcoded
+    # For a pull_request event, clone the PR's own head repo+commit (so a
+    # PR that updates tcc.exe/libgc.a is actually tested) instead of the
+    # unrelated target branch's current tip - a hardcoded
     # `git clone --branch thirdparty-freebsd-amd64 .../vlang/tccbin.git`
     # would silently test only the already-merged target branch
-    # regardless of what the PR proposes. push/workflow_dispatch have
-    # no PR context, so they fall back to whatever ref triggered the
-    # run. Set at job level (matching update_tccbin.yml's own working
-    # BSD job env, which only ever references github.*/secrets.*, never
-    # steps.* - step-level env on the "Start VM" step was tried first
-    # and empirically did NOT get forwarded into the VM by
-    # environment_variables, unlike this job-level placement).
+    # regardless of what the PR proposes. push/workflow_dispatch have no
+    # PR context, so they fall back to the event's own repository/commit
+    # (not a branch *name*, which is mutable: another push landing while
+    # this run is queued/starting would otherwise make the resolved
+    # value, a ref name, silently resolve to a different commit than the
+    # one that triggered this run - Codex pullrequestreview-4780048339 on
+    # vlang/tccbin#75). Set at job level (matching update_tccbin.yml's
+    # own working BSD job env, which only ever references
+    # github.*/secrets.*, never steps.* - step-level env on the "Start
+    # VM" step was tried first and empirically did NOT get forwarded
+    # into the VM by environment_variables, unlike this job-level
+    # placement).
     env:
-      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
-      TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || github.event.repository.clone_url }}
+      TCCBIN_CLONE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       # cross-platform-actions/action boots a real FreeBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
@@ -32,15 +37,20 @@ jobs:
       # directly inside the VM (rather than actions/checkout on the
       # runner + sync_files) mirrors that proven-working pattern instead
       # of relying on an unverified file-permission-preserving sync.
+      # Pinned to the v1.3.0 tag's commit (resolved via the GitHub API)
+      # rather than the mutable tag itself, so a retag upstream can't
+      # silently swap in different third-party code here without a
+      # review-visible diff (Codex pullrequestreview-4780048339 on
+      # vlang/tccbin#75).
       - name: Start freebsd-amd64 VM
-        uses: cross-platform-actions/action@v1.3.0
+        uses: cross-platform-actions/action@4347c661239bf5dcd0cd77708061488d907343d6 # v1.3.0
         with:
           operating_system: freebsd
           version: '15.1'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
+          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_SHA
 
       - name: fetch shared conformance suite and this branch's binaries
         shell: cpa.sh {0}
@@ -48,16 +58,35 @@ jobs:
           set -eu
           sudo pkg install -y bash git
 
-          git clone --branch "$TCCBIN_CLONE_REF" --depth=1 \
-            "$TCCBIN_CLONE_URL" thirdparty/tcc
+          # Fetch the exact commit that triggered this run, not a branch
+          # name - `git clone --branch <name>` would resolve whatever
+          # that name points to *at clone time*, which can race a push
+          # that lands after this run started (Codex pullrequestreview-
+          # 4780048339 on vlang/tccbin#75).
+          mkdir thirdparty/tcc && cd thirdparty/tcc
+          git init -q
+          git remote add origin "$TCCBIN_CLONE_URL"
+          git fetch --depth=1 origin "$TCCBIN_CLONE_SHA"
+          git checkout -q FETCH_HEAD
+          cd ../..
 
           # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
           # (the shared cross-platform conformance suite) both live in
-          # the main v repo, not here.
-          git clone --filter=blob:none --no-checkout --depth=1 \
-            https://github.com/vlang/v.git vsrc
-          git -C vsrc sparse-checkout set --no-cone thirdparty/libgc thirdparty/tccbin_tests
-          git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+          # the main v repo, not here. A plain `git clone --depth=1`
+          # only ever contains the CURRENT tip commit's objects - once
+          # vlang/v advances past this pinned SHA, that historical commit
+          # object won't exist in a fresh shallow clone and this checkout
+          # would fail (Codex P1, pullrequestreview-4780048339 on
+          # vlang/tccbin#75, line 60). Fetch that exact SHA directly
+          # instead of cloning HEAD and hoping it's still there.
+          mkdir vsrc && cd vsrc
+          git init -q
+          git remote add origin https://github.com/vlang/v.git
+          git sparse-checkout init --no-cone
+          git sparse-checkout set thirdparty/libgc thirdparty/tccbin_tests
+          git fetch --filter=blob:none --depth=1 origin c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+          git checkout -q FETCH_HEAD
+          cd ..
 
           chmod +x thirdparty/tcc/tcc.exe
 
@@ -102,13 +131,40 @@ jobs:
           fi
           echo "no-GC compile+crash check passed (killed by SIGSEGV as expected)"
 
+      # continue-on-error alone would also swallow an unrelated failure
+      # (a corrupted libgc.a, a bad checkout, run.sh going missing) as if
+      # it were the known etext/end failure, and the blocking crash-only
+      # step above never references libgc.a at all - so a real
+      # regression in the archive itself could pass CI unnoticed (Codex
+      # pullrequestreview-4780048339 on vlang/tccbin#75, line 107).
+      # Assert the exact known failure signature instead, mirroring
+      # macos-arm64's own libgc.a XFAIL lane: any other failure shape
+      # (or an unexpected full pass, meaning the etext/end fix landed)
+      # fails the job for real.
       - name: run shared conformance tests (libgc.a - XFAIL until the etext/end tcc fix ships)
         shell: cpa.sh {0}
-        continue-on-error: true
         run: |
-          set -eu
-          bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" freebsd -- \
+          set +e
+          output=$(bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" freebsd -- \
               -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
               -I "$PWD/vsrc/thirdparty/libgc/include" \
               "$PWD/thirdparty/tcc/lib/libgc.a" \
-              -lpthread
+              -lpthread 2>&1)
+          code=$?
+          set -e
+          echo "$output"
+
+          if [ "$code" -eq 0 ]; then
+            echo "expected the known etext/end unresolved-symbol failure, but this lane fully passed - the upstream tcc fix must have landed; remove this XFAIL special-casing and fold it back into a single blocking lane." >&2
+            exit 1
+          fi
+
+          case "$output" in
+            *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
+              echo "known XFAIL: etext/end still unresolved on FreeBSD tcc, as expected - not blocking CI"
+              ;;
+            *)
+              echo "libgc.a lane failed, but NOT with the known/expected signature (PASS crash, FAIL gc_alloc/hello with compile error) - this looks like a different, unexpected problem and should not be silently treated as the known XFAIL." >&2
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -168,28 +168,43 @@ jobs:
           # references GC symbols) while gc_alloc/hello both report
           # "compile error", matching this same summary shape for an
           # unrelated reason (Codex pullrequestreview-4780219278 on
-          # vlang/tccbin#75). Compile hello.c directly to capture the
-          # real tcc stderr and assert it's specifically the known
-          # etext/end unresolved-symbol error.
-          direct_err=$(thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
+          # vlang/tccbin#75). Compile BOTH failing tests directly to
+          # capture their real tcc stderr and assert each is specifically
+          # the known etext/end unresolved-symbol error - checking only
+          # one of the two (e.g. hello.c) would let an unrelated
+          # regression isolated to the OTHER test (gc_alloc.c) hide
+          # behind this same summary shape and pass unnoticed (Codex
+          # pullrequestreview-4780815399 on vlang/tccbin#75).
+          direct_err_hello=$(thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
               -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
               -I vsrc/thirdparty/libgc/include \
               thirdparty/tcc/lib/libgc.a \
               -lpthread \
               -o /tmp/hello_xfail_probe 2>&1) || true
+          direct_err_gc_alloc=$(thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/gc_alloc.c \
+              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
+              -I vsrc/thirdparty/libgc/include \
+              thirdparty/tcc/lib/libgc.a \
+              -lpthread \
+              -o /tmp/gc_alloc_xfail_probe 2>&1) || true
+
+          is_known_etext_end() {
+            case "$1" in
+              *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*) return 0 ;;
+              *) return 1 ;;
+            esac
+          }
 
           case "$output" in
             *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
-              case "$direct_err" in
-                *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*)
-                  echo "known XFAIL: etext/end still unresolved on FreeBSD tcc, as expected - not blocking CI"
-                  ;;
-                *)
-                  echo "libgc.a lane failed with the known summary shape, but the direct hello.c compile error does NOT mention an unresolved etext/end symbol - this looks like a different, unexpected regression:" >&2
-                  echo "$direct_err" >&2
-                  exit 1
-                  ;;
-              esac
+              if is_known_etext_end "$direct_err_hello" && is_known_etext_end "$direct_err_gc_alloc"; then
+                echo "known XFAIL: etext/end still unresolved on FreeBSD tcc for both gc_alloc.c and hello.c, as expected - not blocking CI"
+              else
+                echo "libgc.a lane failed with the known summary shape, but at least one of gc_alloc.c/hello.c's direct compile errors does NOT mention an unresolved etext/end symbol - this looks like a different, unexpected regression:" >&2
+                echo "hello.c: $direct_err_hello" >&2
+                echo "gc_alloc.c: $direct_err_gc_alloc" >&2
+                exit 1
+              fi
               ;;
             *)
               echo "libgc.a lane failed, but NOT with the known/expected summary (PASS crash, FAIL gc_alloc/hello with compile error) - this looks like a different, unexpected problem and should not be silently treated as the known XFAIL." >&2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -176,7 +176,7 @@ jobs:
               -I vsrc/thirdparty/libgc/include \
               thirdparty/tcc/lib/libgc.a \
               -lpthread \
-              -o /tmp/hello_xfail_probe 2>&1)
+              -o /tmp/hello_xfail_probe 2>&1) || true
 
           case "$output" in
             *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -159,12 +159,40 @@ jobs:
             exit 1
           fi
 
+          # The pinned run.sh only ever prints "(compile error)" with no
+          # detail, so the summary-line match above can't tell "the known
+          # etext/end bug" apart from a DIFFERENT static-link regression
+          # that happens to fail the same two tests - e.g. a PR that
+          # replaces libgc.a with a valid-but-incomplete archive lacking
+          # the GC objects entirely: crash.c still compiles (it never
+          # references GC symbols) while gc_alloc/hello both report
+          # "compile error", matching this same summary shape for an
+          # unrelated reason (Codex pullrequestreview-4780219278 on
+          # vlang/tccbin#75). Compile hello.c directly to capture the
+          # real tcc stderr and assert it's specifically the known
+          # etext/end unresolved-symbol error.
+          direct_err=$(thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
+              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
+              -I vsrc/thirdparty/libgc/include \
+              thirdparty/tcc/lib/libgc.a \
+              -lpthread \
+              -o /tmp/hello_xfail_probe 2>&1)
+
           case "$output" in
             *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
-              echo "known XFAIL: etext/end still unresolved on FreeBSD tcc, as expected - not blocking CI"
+              case "$direct_err" in
+                *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*)
+                  echo "known XFAIL: etext/end still unresolved on FreeBSD tcc, as expected - not blocking CI"
+                  ;;
+                *)
+                  echo "libgc.a lane failed with the known summary shape, but the direct hello.c compile error does NOT mention an unresolved etext/end symbol - this looks like a different, unexpected regression:" >&2
+                  echo "$direct_err" >&2
+                  exit 1
+                  ;;
+              esac
               ;;
             *)
-              echo "libgc.a lane failed, but NOT with the known/expected signature (PASS crash, FAIL gc_alloc/hello with compile error) - this looks like a different, unexpected problem and should not be silently treated as the known XFAIL." >&2
+              echo "libgc.a lane failed, but NOT with the known/expected summary (PASS crash, FAIL gc_alloc/hello with compile error) - this looks like a different, unexpected problem and should not be silently treated as the known XFAIL." >&2
               exit 1
               ;;
           esac

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -131,6 +131,32 @@ jobs:
           fi
           echo "no-GC compile+crash check passed (killed by SIGSEGV as expected)"
 
+          # crash.c exiting 139 only proves SOME crash happened - if a
+          # broken libtcc1.a/crt or startup path made EVERY program
+          # segfault immediately (before ever reaching the intentional
+          # null-pointer dereference), this check would still see exit
+          # 139 and wrongly call it "expected" (Codex pullrequestreview-
+          # 4781468264 on vlang/tccbin#75). The GC-backed lane below
+          # can't provide this positive check either, since it's
+          # expected to fail at link time. Compile and run a trivial,
+          # non-crashing program with the same no-GC flags, requiring it
+          # to actually complete and exit 0 - proving the toolchain can
+          # still produce a genuinely working binary, not just one that
+          # crashes regardless of source.
+          cat > /tmp/nogc_trivial.c <<'TRIVIALEOF'
+          int main(void) { return 0; }
+          TRIVIALEOF
+          thirdparty/tcc/tcc.exe /tmp/nogc_trivial.c -o /tmp/nogc_trivial
+          set +e
+          /tmp/nogc_trivial
+          trivial_code=$?
+          set -e
+          if [ "$trivial_code" -ne 0 ]; then
+            echo "expected the trivial no-GC program to exit 0, got $trivial_code - the no-GC toolchain path may be broken (e.g. crashing at startup) even though the crash.c check above happened to pass" >&2
+            exit 1
+          fi
+          echo "trivial no-GC success check passed (exit=0)"
+
       # continue-on-error alone would also swallow an unrelated failure
       # (a corrupted libgc.a, a bad checkout, run.sh going missing) as if
       # it were the known etext/end failure, and the blocking crash-only
@@ -202,7 +228,17 @@ jobs:
               *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*) ;;
               *) return 1 ;;
             esac
-            other=$(printf '%s\n' "$1" | grep -oE "undefined symbol '[^']+'" | grep -v -E "undefined symbol '(etext|end)'")
+            # Filtering only "undefined symbol '...'" lines and checking
+            # their NAMES misses a wholly DIFFERENT kind of tcc error
+            # (invalid object, relocation error, etc.) riding alongside
+            # the known one - such a line simply wouldn't match the
+            # "undefined symbol" pattern at extraction, so `other` would
+            # stay empty and this would wrongly accept the XFAIL (Codex
+            # pullrequestreview-4781468264 on vlang/tccbin#75). Match on
+            # tcc's actual error-line prefix instead, so ANY tcc error
+            # line that isn't specifically etext/end gets caught, not
+            # just a differently-named undefined symbol.
+            other=$(printf '%s\n' "$1" | grep -E '^tcc: error:' | grep -v -E "undefined symbol '(etext|end)'")
             [ -z "$other" ]
           }
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,26 +10,39 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # For a pull_request event, clone the PR's own head repo+commit (so a
-    # PR that updates tcc.exe/libgc.a is actually tested) instead of the
-    # unrelated target branch's current tip - a hardcoded
-    # `git clone --branch thirdparty-freebsd-amd64 .../vlang/tccbin.git`
-    # would silently test only the already-merged target branch
-    # regardless of what the PR proposes. push/workflow_dispatch have no
-    # PR context, so they fall back to the event's own repository/commit
-    # (not a branch *name*, which is mutable: another push landing while
-    # this run is queued/starting would otherwise make the resolved
-    # value, a ref name, silently resolve to a different commit than the
-    # one that triggered this run - Codex pullrequestreview-4780048339 on
-    # vlang/tccbin#75). Set at job level (matching update_tccbin.yml's
-    # own working BSD job env, which only ever references
-    # github.*/secrets.*, never steps.* - step-level env on the "Start
-    # VM" step was tried first and empirically did NOT get forwarded
-    # into the VM by environment_variables, unlike this job-level
-    # placement).
+    # `github.sha` and `github.event.repository.clone_url` are used
+    # uniformly across all 3 trigger event types, and correctly cover
+    # each:
+    # - pull_request: `github.sha` is GitHub's own synthesized MERGE
+    #   commit (what the target branch would actually look like if
+    #   this PR were merged right now), not the PR branch's own head -
+    #   testing only the head tree in isolation could pass a PR whose
+    #   OWN commit works fine, while the actual merge result (combined
+    #   with whatever the target branch has since gained) is broken
+    #   (Codex pullrequestreview-4781865117 on vlang/tccbin#75). That
+    #   merge commit exists ONLY as an object in the base repo
+    #   (vlang/tccbin, exposed via `refs/pull/<n>/merge`) - never in a
+    #   contributor's fork - so this must clone from
+    #   `github.event.repository.clone_url` (the base repo), not the
+    #   fork's URL, regardless of where the PR originated.
+    # - push/workflow_dispatch: `github.sha`/`github.event.repository`
+    #   are simply the pushed/dispatched commit and the repo it lives
+    #   in - already exactly what should be tested.
+    # In every case, `github.sha` is fixed for this run's entire
+    # lifetime once the triggering event fires (a later push creates a
+    # brand new run with its own new `github.sha`, it doesn't mutate
+    # this one) - so this is exactly as race-safe against a
+    # mid-queue push as the earlier head.sha-based approach was (Codex
+    # pullrequestreview-4780048339 on vlang/tccbin#75), while also
+    # testing the actual merge result instead of the head tree alone.
+    # Set at job level (matching update_tccbin.yml's own working BSD
+    # job env, which only ever references github.*/secrets.*, never
+    # steps.* - step-level env on the "Start VM" step was tried first
+    # and empirically did NOT get forwarded into the VM by
+    # environment_variables, unlike this job-level placement).
     env:
-      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || github.event.repository.clone_url }}
-      TCCBIN_CLONE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      TCCBIN_CLONE_URL: ${{ github.event.repository.clone_url }}
+      TCCBIN_CLONE_SHA: ${{ github.sha }}
     steps:
       # cross-platform-actions/action boots a real FreeBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -26,7 +26,7 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
 
-      - name: run shared conformance tests
+      - name: fetch shared conformance suite and this branch's binaries
         shell: cpa.sh {0}
         run: |
           set -eu
@@ -45,111 +45,40 @@ jobs:
 
           chmod +x thirdparty/tcc/tcc.exe
 
-          # TEMPORARY diagnostic: run.sh swallows compile stderr, so on
-          # first failure here we can't see *why* linking failed. Show
-          # it directly before running the real suite.
-          thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
-              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
-              -I "$PWD/vsrc/thirdparty/libgc/include" \
-              "$PWD/thirdparty/tcc/lib/libgc.a" \
-              -lpthread \
-              -o /tmp/hello_diag || true
+      # tcc on FreeBSD cannot currently link the bundled libgc.a: its
+      # linker only ever defines the glibc-style _etext/_edata/_end
+      # (see tccelf.c's tcc_add_linker_symbols), never the plain BSD-
+      # style etext/edata/end that BDWGC's FreeBSD data-segment-scanning
+      # code references directly - so any GC-dependent program fails
+      # with "undefined symbol 'etext'"/"'end'". Root-caused and a fix
+      # verified against a real FreeBSD VM (patched tcc successfully
+      # builds+runs shared/hello.c against this same libgc.a); the fix
+      # is being submitted upstream to tinycc-devel but isn't in any
+      # shipped tcc.exe yet, so it can't be relied on here.
+      #
+      # crash.c doesn't touch the GC at all, so it's checked directly
+      # (bypassing run.sh, which would otherwise apply the same GC
+      # flags to every test) as the real, blocking regression check for
+      # this platform's tcc/libtcc1.a/crt pairing.
+      - name: run shared conformance tests (crash only, no GC - blocking)
+        shell: cpa.sh {0}
+        run: |
+          set -eu
+          thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/crash.c \
+              -o /tmp/crash_nogc
+          if /tmp/crash_nogc; then
+            echo "expected a nonzero exit from an unguarded null-pointer dereference, got 0" >&2
+            exit 1
+          fi
+          echo "no-GC compile+crash check passed"
 
-          # The bundled tcc.exe resolves its own crt/libtcc1.a via a path
-          # relative to the process's working directory (confirmed on
-          # linux-amd64/macos-arm64's CI) - thirdparty/tcc/tcc.exe is
-          # already correctly placed relative to $PWD here since we just
-          # cloned it there directly.
+      - name: run shared conformance tests (libgc.a - XFAIL until the etext/end tcc fix ships)
+        shell: cpa.sh {0}
+        continue-on-error: true
+        run: |
+          set -eu
           bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" freebsd -- \
               -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
               -I "$PWD/vsrc/thirdparty/libgc/include" \
               "$PWD/thirdparty/tcc/lib/libgc.a" \
               -lpthread
-
-  # TEMPORARY: verifies a candidate tinycc fix for the 'undefined symbol
-  # etext/end' failure above, before submitting it upstream. Builds a
-  # patched tcc from vanilla tinycc source (there's no GitHub mirror to
-  # push a real branch to - tinycc's canonical repo is repo.or.cz, using
-  # email patch submission, not PRs) and tests it against this branch's
-  # already-committed libgc.a. Remove this job once the fix is confirmed
-  # and submitted - it's not part of the branch's real CI.
-  verify-etext-fix:
-    runs-on: ubuntu-latest
-    steps:
-      # repo.or.cz (tinycc's canonical host - no GitHub mirror exists)
-      # resets connections from inside the FreeBSD VM every time
-      # (reproduced twice) - cloning + patching here on the runner instead
-      # avoids that network path entirely; sync_files: runner-to-vm below
-      # carries the already-patched source into the VM via rsync (which
-      # preserves permissions) before each cpa.sh step runs.
-      - name: clone and patch tinycc on the runner
-        run: |
-          set -eu
-          cat > etext_fix.patch <<'PATCHEOF'
-          diff --git a/tccelf.c b/tccelf.c
-          index 7e9758af..f9ae676c 100644
-          --- a/tccelf.c
-          +++ b/tccelf.c
-          @@ -1890,6 +1890,19 @@ static void tcc_add_linker_symbols(TCCState *s1)
-           #if TARGETOS_OpenBSD
-               set_global_sym(s1, "__executable_start", NULL, ELF_START_ADDR);
-           #endif
-          +#if TARGETOS_BSD
-          +    /* Traditional BSD systems provide the plain (non-underscore) names
-          +       as the primary linker-provided segment-boundary symbols, unlike
-          +       glibc/Linux where they're only weak aliases of _etext/_edata/_end
-          +       supplied by the C library's own crt objects - so code that
-          +       references the plain names directly (e.g. BDWGC's FreeBSD
-          +       data-segment-scanning code looks up `etext`/`end` to find its
-          +       conservative-GC root region) links fine under a BSD system's
-          +       native linker but fails here with "undefined symbol" errors. */
-          +    set_global_sym(s1, "etext", text_section, -1);
-          +    set_global_sym(s1, "edata", data_section, -1);
-          +    set_global_sym(s1, "end", bss_section, -1);
-          +#endif
-           #ifdef TCC_TARGET_RISCV64
-               /* XXX should be .sdata+0x800, not .data+0x800 */
-               set_global_sym(s1, "__global_pointer$", data_section, 0x800);
-          PATCHEOF
-
-          git clone --quiet git://repo.or.cz/tinycc.git tinycc-src
-          git -C tinycc-src apply --verbose "$PWD/etext_fix.patch"
-
-      - name: Start freebsd-amd64 VM
-        uses: cross-platform-actions/action@v1.3.0
-        with:
-          operating_system: freebsd
-          version: '15.1'
-          memory: 4G
-          shell: sh
-          sync_files: runner-to-vm
-
-      - name: build patched tcc and test against bundled libgc.a
-        shell: cpa.sh {0}
-        run: |
-          set -eu
-          sudo pkg install -y bash git gmake
-
-          cd tinycc-src
-          CC=cc ./configure --prefix=/tmp/tcc-patched --cc=cc
-          gmake -j"$(sysctl -n hw.ncpu)"
-          gmake install
-          /tmp/tcc-patched/bin/tcc --version
-          cd ..
-
-          git clone --branch thirdparty-freebsd-amd64 --depth=1 \
-            https://github.com/vlang/tccbin.git thirdparty/tcc
-          git clone --filter=blob:none --no-checkout --depth=1 \
-            https://github.com/vlang/v.git vsrc
-          git -C vsrc sparse-checkout set --no-cone thirdparty/libgc thirdparty/tccbin_tests
-          git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
-
-          echo "=== testing PATCHED tcc against bundled libgc.a ==="
-          /tmp/tcc-patched/bin/tcc vsrc/thirdparty/tccbin_tests/shared/hello.c \
-              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
-              -I "$PWD/vsrc/thirdparty/libgc/include" \
-              -I "$PWD/thirdparty/tcc/include" \
-              "$PWD/thirdparty/tcc/lib/libgc.a" \
-              -lpthread \
-              -o /tmp/hello_patched
-          /tmp/hello_patched

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,7 +63,7 @@ jobs:
           # that name points to *at clone time*, which can race a push
           # that lands after this run started (Codex pullrequestreview-
           # 4780048339 on vlang/tccbin#75).
-          mkdir thirdparty/tcc && cd thirdparty/tcc
+          mkdir -p thirdparty/tcc && cd thirdparty/tcc
           git init -q
           git remote add origin "$TCCBIN_CLONE_URL"
           git fetch --depth=1 origin "$TCCBIN_CLONE_SHA"
@@ -79,7 +79,7 @@ jobs:
           # would fail (Codex P1, pullrequestreview-4780048339 on
           # vlang/tccbin#75, line 60). Fetch that exact SHA directly
           # instead of cloning HEAD and hoping it's still there.
-          mkdir vsrc && cd vsrc
+          mkdir -p vsrc && cd vsrc
           git init -q
           git remote add origin https://github.com/vlang/v.git
           git sparse-checkout init --no-cone

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
+      TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
     steps:
       # cross-platform-actions/action boots a real FreeBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
@@ -45,9 +48,6 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
-        env:
-          TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
-          TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
 
       - name: fetch shared conformance suite and this branch's binaries
         shell: cpa.sh {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -133,7 +133,8 @@ jobs:
           cd tinycc-src
           CC=cc ./configure --prefix=/tmp/tcc-patched --cc=cc
           gmake -j"$(sysctl -n hw.ncpu)"
-          ./tcc --version
+          gmake install
+          /tmp/tcc-patched/bin/tcc --version
           cd ..
 
           git clone --branch thirdparty-freebsd-amd64 --depth=1 \
@@ -144,7 +145,7 @@ jobs:
           git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
 
           echo "=== testing PATCHED tcc against bundled libgc.a ==="
-          tinycc-src/tcc vsrc/thirdparty/tccbin_tests/shared/hello.c \
+          /tmp/tcc-patched/bin/tcc vsrc/thirdparty/tccbin_tests/shared/hello.c \
               -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
               -I "$PWD/vsrc/thirdparty/libgc/include" \
               -I "$PWD/thirdparty/tcc/include" \

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -65,3 +65,81 @@ jobs:
               -I "$PWD/vsrc/thirdparty/libgc/include" \
               "$PWD/thirdparty/tcc/lib/libgc.a" \
               -lpthread
+
+  # TEMPORARY: verifies a candidate tinycc fix for the 'undefined symbol
+  # etext/end' failure above, before submitting it upstream. Builds a
+  # patched tcc from vanilla tinycc source (there's no GitHub mirror to
+  # push a real branch to - tinycc's canonical repo is repo.or.cz, using
+  # email patch submission, not PRs) and tests it against this branch's
+  # already-committed libgc.a. Remove this job once the fix is confirmed
+  # and submitted - it's not part of the branch's real CI.
+  verify-etext-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Start freebsd-amd64 VM
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: freebsd
+          version: '15.1'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+
+      - name: build patched tcc and test against bundled libgc.a
+        shell: cpa.sh {0}
+        run: |
+          set -eu
+          sudo pkg install -y bash git gmake
+
+          cat > etext_fix.patch <<'PATCHEOF'
+          diff --git a/tccelf.c b/tccelf.c
+          index 7e9758af..f9ae676c 100644
+          --- a/tccelf.c
+          +++ b/tccelf.c
+          @@ -1890,6 +1890,19 @@ static void tcc_add_linker_symbols(TCCState *s1)
+           #if TARGETOS_OpenBSD
+               set_global_sym(s1, "__executable_start", NULL, ELF_START_ADDR);
+           #endif
+          +#if TARGETOS_BSD
+          +    /* Traditional BSD systems provide the plain (non-underscore) names
+          +       as the primary linker-provided segment-boundary symbols, unlike
+          +       glibc/Linux where they're only weak aliases of _etext/_edata/_end
+          +       supplied by the C library's own crt objects - so code that
+          +       references the plain names directly (e.g. BDWGC's FreeBSD
+          +       data-segment-scanning code looks up `etext`/`end` to find its
+          +       conservative-GC root region) links fine under a BSD system's
+          +       native linker but fails here with "undefined symbol" errors. */
+          +    set_global_sym(s1, "etext", text_section, -1);
+          +    set_global_sym(s1, "edata", data_section, -1);
+          +    set_global_sym(s1, "end", bss_section, -1);
+          +#endif
+           #ifdef TCC_TARGET_RISCV64
+               /* XXX should be .sdata+0x800, not .data+0x800 */
+               set_global_sym(s1, "__global_pointer$", data_section, 0x800);
+          PATCHEOF
+
+          git clone --quiet https://repo.or.cz/tinycc.git tinycc-src
+          git -C tinycc-src apply --verbose ../etext_fix.patch
+
+          cd tinycc-src
+          ./configure --prefix=/tmp/tcc-patched
+          gmake -j"$(sysctl -n hw.ncpu)"
+          ./tcc --version
+          cd ..
+
+          git clone --branch thirdparty-freebsd-amd64 --depth=1 \
+            https://github.com/vlang/tccbin.git thirdparty/tcc
+          git clone --filter=blob:none --no-checkout --depth=1 \
+            https://github.com/vlang/v.git vsrc
+          git -C vsrc sparse-checkout set --no-cone thirdparty/libgc thirdparty/tccbin_tests
+          git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+
+          echo "=== testing PATCHED tcc against bundled libgc.a ==="
+          tinycc-src/tcc vsrc/thirdparty/tccbin_tests/shared/hello.c \
+              -DGC_BUILTIN_ATOMIC=1 -DBUS_PAGE_FAULT=T_PAGEFLT -DALL_INTERIOR_POINTERS=1 \
+              -I "$PWD/vsrc/thirdparty/libgc/include" \
+              -I "$PWD/thirdparty/tcc/include" \
+              "$PWD/thirdparty/tcc/lib/libgc.a" \
+              -lpthread \
+              -o /tmp/hello_patched
+          /tmp/hello_patched

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -188,11 +188,22 @@ jobs:
               -lpthread \
               -o /tmp/gc_alloc_xfail_probe 2>&1) || true
 
+          # Unlike macos-amd64's whole-archive-unparseable bug, this
+          # FreeBSD bug is narrow: tcc's linker only ever fails to define
+          # the two plain BSD-style symbols (etext, end) that BDWGC
+          # references directly - nothing else in the archive is
+          # affected. So an exact match here is the correct check: reject
+          # if any unresolved-reference line names a symbol OTHER than
+          # etext/end, since that would mean a genuinely different,
+          # additional regression rode along with the known bug (Codex
+          # pullrequestreview-4780907186 on vlang/tccbin#75).
           is_known_etext_end() {
             case "$1" in
-              *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*) return 0 ;;
+              *"undefined symbol 'etext'"*|*"undefined symbol 'end'"*) ;;
               *) return 1 ;;
             esac
+            other=$(printf '%s\n' "$1" | grep -oE "undefined symbol '[^']+'" | grep -v -E "undefined symbol '(etext|end)'")
+            [ -z "$other" ]
           }
 
           case "$output" in

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -112,7 +112,7 @@ jobs:
                set_global_sym(s1, "__global_pointer$", data_section, 0x800);
           PATCHEOF
 
-          git clone --quiet https://repo.or.cz/tinycc.git tinycc-src
+          git clone --quiet git://repo.or.cz/tinycc.git tinycc-src
           git -C tinycc-src apply --verbose "$PWD/etext_fix.patch"
 
       - name: Start freebsd-amd64 VM


### PR DESCRIPTION
Wires this branch into the shared cross-platform conformance suite
(`thirdparty/tccbin_tests` in vlang/v) via a real FreeBSD VM
(`cross-platform-actions/action`, the same tooling vlang/v's own
`update_tccbin.yml` uses to rebuild this branch's binaries).

No rebuild here — validates the already-committed `tcc.exe`/`lib/libgc.a`
as-is. I don't have FreeBSD access to verify this locally, so relying
on real CI here.

One thing to flag: V's own builder also references `-lgc-threaded` for
this platform+tcc combination (`vlib/builtin/builtin_d_gcboehm.c.v`),
which isn't part of this branch's bundle (only `libgc.a`, not
`libgc-threaded.a`). Starting without it since the bundled `libgc.a`
should be self-sufficient for the shared suite's needs — will adjust
based on what real CI actually shows if it isn't.