### PR TITLE
ci: adopt shared tccbin conformance test suite (openbsd-amd64)

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,14 +54,6 @@ jobs:
 
           chmod +x thirdparty/tcc/tcc.exe
 
-          # TEMPORARY diagnostic: run.sh swallows compile stderr, so on
-          # first failure here we can't see *why* linking failed.
-          thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
-              -DGC_BUILTIN_ATOMIC=1 \
-              -I "$PWD/vsrc/thirdparty/libgc/include" \
-              -L/usr/local/lib -I/usr/local/include -lgc -lpthread \
-              -o /tmp/hello_diag || true
-
           # The bundled tcc.exe resolves its own crt/libtcc1.a via a path
           # relative to the process's working directory (confirmed on
           # linux-amd64/macos-arm64/freebsd-amd64's CI).

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,10 +36,10 @@ jobs:
           # which only ever references /usr/local/lib/libgc.a, never a
           # bundled path, for this exact platform+compiler combination.
           # GC-dependent tests need a system-installed libgc instead.
-          # TEMPORARY diagnostic: list available libgc-ish packages if
-          # the install guess below is wrong, so the next iteration
-          # doesn't have to guess blind a second time.
-          sudo pkg_add libgc || pkg_info -Q gc 2>&1 || true
+          # OpenBSD's port for this is devel/boehm-gc (confirmed via
+          # cvsweb.openbsd.org/ports/devel/) - package name is boehm-gc,
+          # not libgc or gc.
+          sudo pkg_add boehm-gc
 
           git clone --branch thirdparty-openbsd-amd64 --depth=1 \
             https://github.com/vlang/tccbin.git thirdparty/tcc

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,25 @@ jobs:
       # cross-platform-actions/action boots a real OpenBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
       # uses to rebuild this branch's binaries.
+      # For a pull_request event, clone the PR's own head repo+ref
+      # (so a PR that updates tcc.exe/libgc.a is actually tested)
+      # instead of the unrelated target branch's current tip - a
+      # hardcoded `git clone --branch thirdparty-openbsd-amd64
+      # .../vlang/tccbin.git` would silently test only the
+      # already-merged target branch regardless of what the PR
+      # proposes. push/workflow_dispatch have no PR context, so they
+      # fall back to whatever ref actually triggered the run.
+      - name: resolve what to clone
+        id: clone_target
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "url=${{ github.event.pull_request.head.repo.clone_url }}" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "url=https://github.com/vlang/tccbin.git" >> "$GITHUB_OUTPUT"
+            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Start openbsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0
         with:
@@ -22,6 +41,10 @@ jobs:
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
+          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
+        env:
+          TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
+          TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
 
       - name: run shared conformance tests
         shell: cpa.sh {0}
@@ -41,8 +64,8 @@ jobs:
           # not libgc or gc.
           sudo pkg_add boehm-gc
 
-          git clone --branch thirdparty-openbsd-amd64 --depth=1 \
-            https://github.com/vlang/tccbin.git thirdparty/tcc
+          git clone --branch "$TCCBIN_CLONE_REF" --depth=1 \
+            "$TCCBIN_CLONE_URL" thirdparty/tcc
 
           # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
           # (the shared cross-platform conformance suite) both live in

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -71,7 +71,7 @@ jobs:
           # that name points to *at clone time*, which can race a push
           # that lands after this run started (Codex pullrequestreview-
           # 4780049532 on vlang/tccbin#76).
-          mkdir thirdparty/tcc && cd thirdparty/tcc
+          mkdir -p thirdparty/tcc && cd thirdparty/tcc
           git init -q
           git remote add origin "$TCCBIN_CLONE_URL"
           git fetch --depth=1 origin "$TCCBIN_CLONE_SHA"
@@ -88,7 +88,7 @@ jobs:
           # P1 on the sibling freebsd-amd64 workflow, pullrequestreview-
           # 4780048339 on vlang/tccbin#75 line 60). Fetch that exact SHA
           # directly instead of cloning HEAD and hoping it's still there.
-          mkdir vsrc && cd vsrc
+          mkdir -p vsrc && cd vsrc
           git init -q
           git remote add origin https://github.com/vlang/v.git
           git sparse-checkout init --no-cone

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
+      TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
     steps:
       # cross-platform-actions/action boots a real OpenBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
@@ -42,9 +45,6 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
-        env:
-          TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
-          TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
 
       - name: run shared conformance tests
         shell: cpa.sh {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,34 +10,43 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    # For a pull_request event, clone the PR's own head repo+ref (so a
-    # PR that updates tcc.exe/libgc.a is actually tested) instead of
-    # the unrelated target branch's current tip - a hardcoded
+    # For a pull_request event, clone the PR's own head repo+commit (so a
+    # PR that updates tcc.exe/libgc.a is actually tested) instead of the
+    # unrelated target branch's current tip - a hardcoded
     # `git clone --branch thirdparty-openbsd-amd64 .../vlang/tccbin.git`
     # would silently test only the already-merged target branch
-    # regardless of what the PR proposes. push/workflow_dispatch have
-    # no PR context, so they fall back to whatever ref triggered the
-    # run. Set at job level (matching update_tccbin.yml's own working
-    # BSD job env, which only ever references github.*/secrets.*, never
-    # steps.* - step-level env on the "Start VM" step was tried first
-    # and empirically did NOT get forwarded into the VM by
-    # environment_variables, unlike this job-level placement).
+    # regardless of what the PR proposes. push/workflow_dispatch have no
+    # PR context, so they fall back to the event's own repository/commit
+    # (not a branch *name*, which is mutable: another push landing while
+    # this run is queued/starting would otherwise make TCCBIN_CLONE_SHA's
+    # predecessor, a ref name, silently resolve to a different commit
+    # than the one that triggered this run - Codex pullrequestreview-
+    # 4780049532 on vlang/tccbin#76). Set at job level (matching
+    # update_tccbin.yml's own working BSD job env, which only ever
+    # references github.*/secrets.*, never steps.* - step-level env on
+    # the "Start VM" step was tried first and empirically did NOT get
+    # forwarded into the VM by environment_variables, unlike this
+    # job-level placement).
     env:
-      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
-      TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || github.event.repository.clone_url }}
+      TCCBIN_CLONE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     steps:
       # cross-platform-actions/action boots a real OpenBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
-      # uses to rebuild this branch's binaries.
+      # uses to rebuild this branch's binaries. Pinned to the v1.3.0
+      # tag's commit (resolved via the GitHub API) rather than the
+      # mutable tag itself, so a retag upstream can't silently swap in
+      # different third-party code here without a review-visible diff
+      # (Codex pullrequestreview-4780049532 on vlang/tccbin#76).
       - name: Start openbsd-amd64 VM
-        uses: cross-platform-actions/action@v1.3.0
+        uses: cross-platform-actions/action@4347c661239bf5dcd0cd77708061488d907343d6 # v1.3.0
         with:
           operating_system: openbsd
           version: '7.8'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
+          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_SHA
 
       - name: run shared conformance tests
         shell: cpa.sh {0}
@@ -57,16 +66,36 @@ jobs:
           # not libgc or gc.
           sudo pkg_add boehm-gc
 
-          git clone --branch "$TCCBIN_CLONE_REF" --depth=1 \
-            "$TCCBIN_CLONE_URL" thirdparty/tcc
+          # Fetch the exact commit that triggered this run, not a branch
+          # name - `git clone --branch <name>` would resolve whatever
+          # that name points to *at clone time*, which can race a push
+          # that lands after this run started (Codex pullrequestreview-
+          # 4780049532 on vlang/tccbin#76).
+          mkdir thirdparty/tcc && cd thirdparty/tcc
+          git init -q
+          git remote add origin "$TCCBIN_CLONE_URL"
+          git fetch --depth=1 origin "$TCCBIN_CLONE_SHA"
+          git checkout -q FETCH_HEAD
+          cd ../..
 
           # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
           # (the shared cross-platform conformance suite) both live in
-          # the main v repo, not here.
-          git clone --filter=blob:none --no-checkout --depth=1 \
-            https://github.com/vlang/v.git vsrc
-          git -C vsrc sparse-checkout set --no-cone thirdparty/libgc thirdparty/tccbin_tests
-          git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+          # the main v repo, not here. A plain `git clone --depth=1`
+          # only ever contains the CURRENT tip commit's objects - once
+          # vlang/v advances past this pinned SHA, that historical
+          # commit object won't exist in a fresh shallow clone and this
+          # checkout would fail (the same class of bug Codex flagged as
+          # P1 on the sibling freebsd-amd64 workflow, pullrequestreview-
+          # 4780048339 on vlang/tccbin#75 line 60). Fetch that exact SHA
+          # directly instead of cloning HEAD and hoping it's still there.
+          mkdir vsrc && cd vsrc
+          git init -q
+          git remote add origin https://github.com/vlang/v.git
+          git sparse-checkout init --no-cone
+          git sparse-checkout set thirdparty/libgc thirdparty/tccbin_tests
+          git fetch --filter=blob:none --depth=1 origin c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+          git checkout -q FETCH_HEAD
+          cd ..
 
           chmod +x thirdparty/tcc/tcc.exe
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,22 +10,25 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    # For a pull_request event, clone the PR's own head repo+ref (so a
+    # PR that updates tcc.exe/libgc.a is actually tested) instead of
+    # the unrelated target branch's current tip - a hardcoded
+    # `git clone --branch thirdparty-openbsd-amd64 .../vlang/tccbin.git`
+    # would silently test only the already-merged target branch
+    # regardless of what the PR proposes. push/workflow_dispatch have
+    # no PR context, so they fall back to whatever ref triggered the
+    # run. Set at job level (matching update_tccbin.yml's own working
+    # BSD job env, which only ever references github.*/secrets.*, never
+    # steps.* - step-level env on the "Start VM" step was tried first
+    # and empirically did NOT get forwarded into the VM by
+    # environment_variables, unlike this job-level placement).
+    env:
+      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
+      TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
     steps:
       # cross-platform-actions/action boots a real OpenBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
       # uses to rebuild this branch's binaries.
-      #
-      # For a pull_request event, clone the PR's own head repo+ref (so
-      # a PR that updates tcc.exe/libgc.a is actually tested) instead
-      # of the unrelated target branch's current tip - a hardcoded
-      # `git clone --branch thirdparty-openbsd-amd64 .../vlang/tccbin.git`
-      # would silently test only the already-merged target branch
-      # regardless of what the PR proposes. push/workflow_dispatch have
-      # no PR context, so they fall back to whatever ref triggered the
-      # run. Computed inline here (not a separate step + job-level env)
-      # because job-level env can't reference the steps context at all -
-      # that's a schema violation that fails the whole workflow file,
-      # not just this expression.
       - name: Start openbsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0
         with:
@@ -35,9 +38,6 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
-        env:
-          TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
-          TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: run shared conformance tests
         shell: cpa.sh {0}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,71 @@
+name: build and test (openbsd-amd64)
+
+on:
+  push:
+    branches: [thirdparty-openbsd-amd64]
+  pull_request:
+    branches: [thirdparty-openbsd-amd64]
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # cross-platform-actions/action boots a real OpenBSD VM inside this
+      # Linux runner - the same action vlang/v's own update_tccbin.yml
+      # uses to rebuild this branch's binaries.
+      - name: Start openbsd-amd64 VM
+        uses: cross-platform-actions/action@v1.3.0
+        with:
+          operating_system: openbsd
+          version: '7.8'
+          memory: 4G
+          shell: sh
+          sync_files: runner-to-vm
+
+      - name: run shared conformance tests
+        shell: cpa.sh {0}
+        run: |
+          set -eu
+          sudo pkg_add bash git
+
+          # This branch (unlike linux-amd64/macos-arm64/freebsd-amd64)
+          # ships no libgc.a/.dylib at all - confirmed by inspecting its
+          # tree, and matching V's own builder
+          # (vlib/builtin/builtin_d_gcboehm.c.v's openbsd+tinyc branch),
+          # which only ever references /usr/local/lib/libgc.a, never a
+          # bundled path, for this exact platform+compiler combination.
+          # GC-dependent tests need a system-installed libgc instead.
+          # TEMPORARY diagnostic: list available libgc-ish packages if
+          # the install guess below is wrong, so the next iteration
+          # doesn't have to guess blind a second time.
+          sudo pkg_add libgc || pkg_info -Q gc 2>&1 || true
+
+          git clone --branch thirdparty-openbsd-amd64 --depth=1 \
+            https://github.com/vlang/tccbin.git thirdparty/tcc
+
+          # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
+          # (the shared cross-platform conformance suite) both live in
+          # the main v repo, not here.
+          git clone --filter=blob:none --no-checkout --depth=1 \
+            https://github.com/vlang/v.git vsrc
+          git -C vsrc sparse-checkout set --no-cone thirdparty/libgc thirdparty/tccbin_tests
+          git -C vsrc checkout c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
+
+          chmod +x thirdparty/tcc/tcc.exe
+
+          # TEMPORARY diagnostic: run.sh swallows compile stderr, so on
+          # first failure here we can't see *why* linking failed.
+          thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/hello.c \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -I "$PWD/vsrc/thirdparty/libgc/include" \
+              -L/usr/local/lib -I/usr/local/include -lgc -lpthread \
+              -o /tmp/hello_diag || true
+
+          # The bundled tcc.exe resolves its own crt/libtcc1.a via a path
+          # relative to the process's working directory (confirmed on
+          # linux-amd64/macos-arm64/freebsd-amd64's CI).
+          bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" openbsd -- \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -I "$PWD/vsrc/thirdparty/libgc/include" \
+              -L/usr/local/lib -I/usr/local/include -lgc -lpthread

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,32 +10,22 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    env:
-      TCCBIN_CLONE_URL: ${{ steps.clone_target.outputs.url }}
-      TCCBIN_CLONE_REF: ${{ steps.clone_target.outputs.ref }}
     steps:
       # cross-platform-actions/action boots a real OpenBSD VM inside this
       # Linux runner - the same action vlang/v's own update_tccbin.yml
       # uses to rebuild this branch's binaries.
-      # For a pull_request event, clone the PR's own head repo+ref
-      # (so a PR that updates tcc.exe/libgc.a is actually tested)
-      # instead of the unrelated target branch's current tip - a
-      # hardcoded `git clone --branch thirdparty-openbsd-amd64
-      # .../vlang/tccbin.git` would silently test only the
-      # already-merged target branch regardless of what the PR
-      # proposes. push/workflow_dispatch have no PR context, so they
-      # fall back to whatever ref actually triggered the run.
-      - name: resolve what to clone
-        id: clone_target
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "url=${{ github.event.pull_request.head.repo.clone_url }}" >> "$GITHUB_OUTPUT"
-            echo "ref=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
-          else
-            echo "url=https://github.com/vlang/tccbin.git" >> "$GITHUB_OUTPUT"
-            echo "ref=${{ github.ref_name }}" >> "$GITHUB_OUTPUT"
-          fi
-
+      #
+      # For a pull_request event, clone the PR's own head repo+ref (so
+      # a PR that updates tcc.exe/libgc.a is actually tested) instead
+      # of the unrelated target branch's current tip - a hardcoded
+      # `git clone --branch thirdparty-openbsd-amd64 .../vlang/tccbin.git`
+      # would silently test only the already-merged target branch
+      # regardless of what the PR proposes. push/workflow_dispatch have
+      # no PR context, so they fall back to whatever ref triggered the
+      # run. Computed inline here (not a separate step + job-level env)
+      # because job-level env can't reference the steps context at all -
+      # that's a schema violation that fails the whole workflow file,
+      # not just this expression.
       - name: Start openbsd-amd64 VM
         uses: cross-platform-actions/action@v1.3.0
         with:
@@ -45,6 +35,9 @@ jobs:
           shell: sh
           sync_files: runner-to-vm
           environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_REF
+        env:
+          TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || 'https://github.com/vlang/tccbin.git' }}
+          TCCBIN_CLONE_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
 
       - name: run shared conformance tests
         shell: cpa.sh {0}


### PR DESCRIPTION
Wires this branch into the shared cross-platform conformance suite
(`thirdparty/tccbin_tests` in vlang/v) via a real OpenBSD VM
(`cross-platform-actions/action`, same tooling vlang/v's own
`update_tccbin.yml` uses to rebuild this branch's binaries).

This branch ships no libgc at all (unlike the other platforms) —
confirmed by inspecting its tree and matching V's own builder
(`vlib/builtin/builtin_d_gcboehm.c.v`'s openbsd+tinyc branch), which
only ever references `/usr/local/lib/libgc.a`, never a bundled path,
for this exact platform+compiler combination. GC-dependent tests link
against a system-installed `boehm-gc` package instead (OpenBSD's port
for Boehm GC, confirmed via cvsweb.openbsd.org/ports/devel/).

Verified with a real OpenBSD 7.8 VM CI run: 3/3 shared tests pass
(hello, gc_alloc, crash).