### PR TITLE
windows-amd64: restore WSAConnectByName declarations

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,6 +92,65 @@ jobs:
               throw "i386 Unicode WinAPI conformance probe failed"
           }
 
+      - name: validate WSAConnectBy WinAPI declarations with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/winapi_wsa_connect_by_name.c"
+          $x64Ansi = "$env:RUNNER_TEMP/winapi_wsa_connect_by_name_x64_ansi.exe"
+          $x64Unicode = "$env:RUNNER_TEMP/winapi_wsa_connect_by_name_x64_unicode.exe"
+          $i386Ansi = "$env:RUNNER_TEMP/winapi_wsa_connect_by_name_i386_ansi.exe"
+          $i386Unicode = "$env:RUNNER_TEMP/winapi_wsa_connect_by_name_i386_unicode.exe"
+
+          & work/thirdparty/tcc/tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -o $x64Ansi $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 ANSI WSAConnectBy WinAPI conformance probe failed"
+          }
+          & $x64Ansi
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 ANSI WSAConnectBy WinAPI conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -DUNICODE -D_UNICODE `
+              -o $x64Unicode $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 Unicode WSAConnectBy WinAPI conformance probe failed"
+          }
+          & $x64Unicode
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 Unicode WSAConnectBy WinAPI conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/i386-win32-tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -o $i386Ansi $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 ANSI WSAConnectBy WinAPI conformance probe failed"
+          }
+          & $i386Ansi
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 ANSI WSAConnectBy WinAPI conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/i386-win32-tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -DUNICODE -D_UNICODE `
+              -o $i386Unicode $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 Unicode WSAConnectBy WinAPI conformance probe failed"
+          }
+          & $i386Unicode
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 Unicode WSAConnectBy WinAPI conformance probe execution failed"
+          }
+
       - name: run shared conformance tests
         shell: pwsh
         run: |

--- a/0004-win32-declare-WSAConnectBy-family.patch
+++ b/0004-win32-declare-WSAConnectBy-family.patch
@@ -1,0 +1,42 @@
+win32: declare WSAConnectByList and WSAConnectByName
+
+WSAConnectByList and WSAConnectByNameA/W are part of the ws2_32 API
+starting at _WIN32_WINNT 0x0600. Add the missing declarations to
+winsock2.h so strict implicit-function-declaration diagnostics keep the
+correct Winsock calling convention on both x64 and i386, and add the
+standard ANSI/Unicode neutral alias for WSAConnectByName.
+
+diff --git a/win32/include/winapi/winsock2.h b/win32/include/winapi/winsock2.h
+--- a/win32/include/winapi/winsock2.h
++++ b/win32/include/winapi/winsock2.h
+@@ -1266,5 +1266,8 @@
+ #ifdef UNICODE
+ #define WSADuplicateSocket WSADuplicateSocketW
++#if (_WIN32_WINNT >= 0x0600)
++#define WSAConnectByName WSAConnectByNameW
++#endif
+ #define WSAEnumProtocols WSAEnumProtocolsW
+ #define WSAAddressToString WSAAddressToStringW
+ #define WSASocket WSASocketW
+@@ -1278,6 +1281,9 @@
+ #define WSASetService WSASetServiceW
+ #else
+ #define WSADuplicateSocket WSADuplicateSocketA
++#if (_WIN32_WINNT >= 0x0600)
++#define WSAConnectByName WSAConnectByNameA
++#endif
+ #define WSAEnumProtocols WSAEnumProtocolsA
+ #define WSASocket WSASocketA
+ #define WSAAddressToString WSAAddressToStringA
+@@ -1340,6 +1346,11 @@
+   WINSOCK_API_LINKAGE SOCKET WSAAPI WSAAccept(SOCKET s,struct sockaddr *addr,LPINT addrlen,LPCONDITIONPROC lpfnCondition,DWORD_PTR dwCallbackData);
+   WINSOCK_API_LINKAGE WINBOOL WSAAPI WSACloseEvent(WSAEVENT hEvent);
+   WINSOCK_API_LINKAGE int WSAAPI WSAConnect(SOCKET s,const struct sockaddr *name,int namelen,LPWSABUF lpCallerData,LPWSABUF lpCalleeData,LPQOS lpSQOS,LPQOS lpGQOS);
++#if (_WIN32_WINNT >= 0x0600)
++  WINSOCK_API_LINKAGE WINBOOL WSAAPI WSAConnectByList(SOCKET s,LPSOCKET_ADDRESS_LIST SocketAddress,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
++  WINSOCK_API_LINKAGE WINBOOL WSAAPI WSAConnectByNameA(SOCKET s,LPCSTR nodename,LPCSTR servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
++  WINSOCK_API_LINKAGE WINBOOL WSAAPI WSAConnectByNameW(SOCKET s,LPWSTR nodename,LPWSTR servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
++#endif
+   WINSOCK_API_LINKAGE WSAEVENT WSAAPI WSACreateEvent(void);
+   WINSOCK_API_LINKAGE int WSAAPI WSADuplicateSocketA(SOCKET s,DWORD dwProcessId,LPWSAPROTOCOL_INFOA lpProtocolInfo);
+   WINSOCK_API_LINKAGE int WSAAPI WSADuplicateSocketW(SOCKET s,DWORD dwProcessId,LPWSAPROTOCOL_INFOW lpProtocolInfo);

--- a/build.ps1
+++ b/build.ps1
@@ -25,6 +25,7 @@ $TccBaseCommit = "d9d02c56401e43be43760b63f7d82f771a7ed1f6"
 $TccPatch1 = Join-Path $PSScriptRoot "0001-tccpe-strip-quotes-and-default-.dll-extension-in-DEF.patch"
 $TccPatch2 = Join-Path $PSScriptRoot "0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch"
 $TccPatch3 = Join-Path $PSScriptRoot "0003-win32-declare-CreateSymbolicLink.patch"
+$TccPatch4 = Join-Path $PSScriptRoot "0004-win32-declare-WSAConnectBy-family.patch"
 $GcPatch = Join-Path $PSScriptRoot "v-ae88ee5-tinycc-bdwgc.patch"
 $OutDir = $PSScriptRoot
 
@@ -44,6 +45,8 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "$TccPatch2 failed to apply" }
     git apply $TccPatch3
     if ($LASTEXITCODE -ne 0) { throw "$TccPatch3 failed to apply" }
+    git apply $TccPatch4
+    if ($LASTEXITCODE -ne 0) { throw "$TccPatch4 failed to apply" }
 
     Set-Location win32
     & .\build-tcc.bat -clean

--- a/include/winapi/winsock2.h
+++ b/include/winapi/winsock2.h
@@ -1265,6 +1265,9 @@ extern "C" {
 
 #ifdef UNICODE
 #define WSADuplicateSocket WSADuplicateSocketW
+#if (_WIN32_WINNT >= 0x0600)
+#define WSAConnectByName WSAConnectByNameW
+#endif
 #define WSAEnumProtocols WSAEnumProtocolsW
 #define WSAAddressToString WSAAddressToStringW
 #define WSASocket WSASocketW
@@ -1278,6 +1281,9 @@ extern "C" {
 #define WSASetService WSASetServiceW
 #else
 #define WSADuplicateSocket WSADuplicateSocketA
+#if (_WIN32_WINNT >= 0x0600)
+#define WSAConnectByName WSAConnectByNameA
+#endif
 #define WSAEnumProtocols WSAEnumProtocolsA
 #define WSASocket WSASocketA
 #define WSAAddressToString WSAAddressToStringA
@@ -1340,6 +1346,11 @@ extern "C" {
   WINSOCK_API_LINKAGE SOCKET WSAAPI WSAAccept(SOCKET s,struct sockaddr *addr,LPINT addrlen,LPCONDITIONPROC lpfnCondition,DWORD_PTR dwCallbackData);
   WINSOCK_API_LINKAGE WINBOOL WSAAPI WSACloseEvent(WSAEVENT hEvent);
   WINSOCK_API_LINKAGE int WSAAPI WSAConnect(SOCKET s,const struct sockaddr *name,int namelen,LPWSABUF lpCallerData,LPWSABUF lpCalleeData,LPQOS lpSQOS,LPQOS lpGQOS);
+#if (_WIN32_WINNT >= 0x0600)
+  WINSOCK_API_LINKAGE WINBOOL WSAAPI WSAConnectByList(SOCKET s,LPSOCKET_ADDRESS_LIST SocketAddress,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+  WINSOCK_API_LINKAGE WINBOOL WSAAPI WSAConnectByNameA(SOCKET s,LPCSTR nodename,LPCSTR servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+  WINSOCK_API_LINKAGE WINBOOL WSAAPI WSAConnectByNameW(SOCKET s,LPWSTR nodename,LPWSTR servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+#endif
   WINSOCK_API_LINKAGE WSAEVENT WSAAPI WSACreateEvent(void);
   WINSOCK_API_LINKAGE int WSAAPI WSADuplicateSocketA(SOCKET s,DWORD dwProcessId,LPWSAPROTOCOL_INFOA lpProtocolInfo);
   WINSOCK_API_LINKAGE int WSAAPI WSADuplicateSocketW(SOCKET s,DWORD dwProcessId,LPWSAPROTOCOL_INFOW lpProtocolInfo);

--- a/tests/winapi_wsa_connect_by_name.c
+++ b/tests/winapi_wsa_connect_by_name.c
@@ -1,0 +1,29 @@
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#include <winsock2.h>
+
+#ifdef UNICODE
+typedef LPWSTR wsa_connect_by_name_string;
+#define WSA_CONNECT_BY_NAME_EXPECTED WSAConnectByNameW
+#else
+typedef LPCSTR wsa_connect_by_name_string;
+#define WSA_CONNECT_BY_NAME_EXPECTED WSAConnectByNameA
+#endif
+
+typedef WINBOOL (WSAAPI *wsa_connect_by_list_fn)(SOCKET s,LPSOCKET_ADDRESS_LIST SocketAddress,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+typedef WINBOOL (WSAAPI *wsa_connect_by_name_a_fn)(SOCKET s,LPCSTR nodename,LPCSTR servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+typedef WINBOOL (WSAAPI *wsa_connect_by_name_w_fn)(SOCKET s,LPWSTR nodename,LPWSTR servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+typedef WINBOOL (WSAAPI *wsa_connect_by_name_fn)(SOCKET s,wsa_connect_by_name_string nodename,wsa_connect_by_name_string servicename,LPDWORD LocalAddressLength,LPSOCKADDR LocalAddress,LPDWORD RemoteAddressLength,LPSOCKADDR RemoteAddress,const struct timeval *timeout,LPWSAOVERLAPPED Reserved);
+
+static volatile wsa_connect_by_list_fn connect_by_list_ptr = WSAConnectByList;
+static volatile wsa_connect_by_name_a_fn connect_by_name_a_ptr = WSAConnectByNameA;
+static volatile wsa_connect_by_name_w_fn connect_by_name_w_ptr = WSAConnectByNameW;
+static volatile wsa_connect_by_name_fn connect_by_name_ptr = WSAConnectByName;
+
+int main(void)
+{
+    return connect_by_list_ptr == 0 ||
+           connect_by_name_a_ptr == 0 ||
+           connect_by_name_w_ptr == 0 ||
+           connect_by_name_ptr != WSA_CONNECT_BY_NAME_EXPECTED;
+}


### PR DESCRIPTION
## Summary

- add the missing ABI-correct `WSAConnectByList` and `WSAConnectByNameA/W` declarations to the bundled Windows `winsock2.h`
- restore the standard ANSI/Unicode `WSAConnectByName` alias
- preserve the header fix in the Windows rebuild pipeline
- add strict x64/i386 ANSI/Unicode compile-and-run regression probes

This fixes Windows TCC builds that use `WSAConnectByNameW` with `-Werror=implicit-function-declaration`, while preserving the existing `ws2_32` import definitions.

## Validation

- rebuilt the Windows bundle from the pinned TinyCC revision
- verified that the stored patch reproduces the bundled header exactly
- passed all four native Windows probes: x64/i386 and ANSI/Unicode
- passed the shared `hello`, `gc_alloc`, `crash`, and `crash_message` conformance tests