### PR TITLE
windows-amd64: restore TinyCC API and math compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -53,6 +53,111 @@ jobs:
         shell: pwsh
         run: work/thirdparty/tcc/build.ps1
 
+      - name: validate exp2 range with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $test = "work/thirdparty/tcc/tests/math_exp2_range.c"
+          $cases = @(
+              @{ Name = "x64"; Compiler = "work/thirdparty/tcc/tcc.exe" },
+              @{ Name = "i386"; Compiler = "work/thirdparty/tcc/i386-win32-tcc.exe" }
+          )
+          $failures = @()
+
+          foreach ($case in $cases) {
+              $token = [guid]::NewGuid().ToString("N")
+              $executable = Join-Path $env:RUNNER_TEMP "math_exp2_range_$token.exe"
+              try {
+                  Write-Host "=== exp2 $($case.Name) compile: $($case.Compiler) ==="
+                  $compileExit = 1
+                  $compileException = $null
+                  try {
+                      & $case.Compiler -Wall -Werror -o $executable $test
+                      $compileExit = $LASTEXITCODE
+                  } catch {
+                      $compileException = $_.Exception.Message
+                  }
+
+                  if ($compileExit -ne 0) {
+                      $failure = "$($case.Name) compile/link exit=$compileExit"
+                      if ($compileException) {
+                          $failure += " exception=$compileException"
+                      }
+                      $failures += $failure
+                      Write-Host "::error title=exp2 $($case.Name) compile::$failure"
+                  } else {
+                      Write-Host "=== exp2 $($case.Name) runtime ==="
+                      $runtimeExit = 1
+                      $runtimeException = $null
+                      try {
+                          & $executable
+                          $runtimeExit = $LASTEXITCODE
+                      } catch {
+                          $runtimeException = $_.Exception.Message
+                      }
+
+                      if ($runtimeExit -ne 0) {
+                          $failure = "$($case.Name) runtime exit=$runtimeExit"
+                          if ($runtimeException) {
+                              $failure += " exception=$runtimeException"
+                          }
+                          $failures += $failure
+                          Write-Host "::error title=exp2 $($case.Name) runtime::$failure"
+                      } else {
+                          Write-Host "=== exp2 $($case.Name) PASS ==="
+                      }
+                  }
+              } finally {
+                  Remove-Item -LiteralPath $executable -Force -ErrorAction SilentlyContinue
+              }
+          }
+
+          if ($failures.Count -ne 0) {
+              Write-Host "=== exp2 range summary: FAIL ==="
+              foreach ($failure in $failures) {
+                  Write-Host "  $failure"
+              }
+              throw "exp2 range validation failed in $($failures.Count) architecture phase(s)"
+          }
+          Write-Host "=== exp2 range summary: PASS ==="
+
+      - name: validate secure CRT fopen_s/freopen_s with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/crt_secure_freopen.c"
+          $cases = @(
+              @{ Id = "x64"; Name = "x64"; Compiler = "work/thirdparty/tcc/tcc.exe" },
+              @{ Id = "i386"; Name = "i386"; Compiler = "work/thirdparty/tcc/i386-win32-tcc.exe" }
+          )
+
+          foreach ($case in $cases) {
+              $token = [guid]::NewGuid().ToString("N")
+              $executable = Join-Path $env:RUNNER_TEMP "crt_secure_freopen_$($case.Id)_$token.exe"
+              $dataPath = Join-Path $env:RUNNER_TEMP "crt_secure_freopen_$($case.Id)_$token.tmp"
+              try {
+                  $compilerArgs = @(
+                      "-Wall",
+                      "-Werror",
+                      "-Werror=implicit-function-declaration",
+                      "-o",
+                      $executable,
+                      $probe
+                  )
+                  & $case.Compiler @compilerArgs
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "$($case.Name) secure CRT fopen_s/freopen_s probe failed to compile or link"
+                  }
+
+                  & $executable $dataPath
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "$($case.Name) secure CRT fopen_s/freopen_s probe failed at runtime"
+                  }
+              } finally {
+                  foreach ($path in @($executable, $dataPath)) {
+                      Remove-Item -LiteralPath $path -Force -ErrorAction SilentlyContinue
+                  }
+              }
+          }
+
       - name: validate WinAPI declarations with x64 and i386 TCC
         shell: pwsh
         run: |
@@ -149,6 +254,135 @@ jobs:
           & $i386Unicode
           if ($LASTEXITCODE -ne 0) {
               throw "i386 Unicode WSAConnectBy WinAPI conformance probe execution failed"
+          }
+
+      - name: validate InetNtop/InetPton WinAPI declarations with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/winapi_inet_ntop_pton.c"
+          $x64Ansi = "$env:RUNNER_TEMP/winapi_inet_ntop_pton_x64_ansi.exe"
+          $x64Unicode = "$env:RUNNER_TEMP/winapi_inet_ntop_pton_x64_unicode.exe"
+          $i386Ansi = "$env:RUNNER_TEMP/winapi_inet_ntop_pton_i386_ansi.exe"
+          $i386Unicode = "$env:RUNNER_TEMP/winapi_inet_ntop_pton_i386_unicode.exe"
+
+          & work/thirdparty/tcc/tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -o $x64Ansi $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 ANSI InetNtop/InetPton WinAPI conformance probe failed"
+          }
+          & $x64Ansi
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 ANSI InetNtop/InetPton WinAPI conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -DUNICODE -D_UNICODE `
+              -o $x64Unicode $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 Unicode InetNtop/InetPton WinAPI conformance probe failed"
+          }
+          & $x64Unicode
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 Unicode InetNtop/InetPton WinAPI conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/i386-win32-tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -o $i386Ansi $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 ANSI InetNtop/InetPton WinAPI conformance probe failed"
+          }
+          & $i386Ansi
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 ANSI InetNtop/InetPton WinAPI conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/i386-win32-tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -DUNICODE -D_UNICODE `
+              -o $i386Unicode $probe -lws2_32
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 Unicode InetNtop/InetPton WinAPI conformance probe failed"
+          }
+          & $i386Unicode
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 Unicode InetNtop/InetPton WinAPI conformance probe execution failed"
+          }
+
+      - name: validate shell drag/drop WinAPI declarations and imports with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/winapi_shell_drag_drop.c"
+          if (-not (Test-Path "work/thirdparty/tcc/lib/shell32.def")) {
+              throw "bundled shell32.def is missing"
+          }
+
+          $cases = @(
+              @{ Id = "x64_ansi"; Name = "x64 ANSI"; Compiler = "work/thirdparty/tcc/tcc.exe"; Defines = @() },
+              @{ Id = "x64_unicode"; Name = "x64 Unicode"; Compiler = "work/thirdparty/tcc/tcc.exe"; Defines = @("-DUNICODE", "-D_UNICODE") },
+              @{ Id = "i386_ansi"; Name = "i386 ANSI"; Compiler = "work/thirdparty/tcc/i386-win32-tcc.exe"; Defines = @() },
+              @{ Id = "i386_unicode"; Name = "i386 Unicode"; Compiler = "work/thirdparty/tcc/i386-win32-tcc.exe"; Defines = @("-DUNICODE", "-D_UNICODE") }
+          )
+          $linkModes = @(
+              @{ Id = "pragma"; Name = "pragma"; Defines = @(); Libraries = @() },
+              @{ Id = "explicit"; Name = "explicit -lshell32"; Defines = @("-DTCCBIN_NO_SHELL32_PRAGMA"); Libraries = @("-lshell32") }
+          )
+
+          foreach ($case in $cases) {
+              foreach ($linkMode in $linkModes) {
+                  $output = "$env:RUNNER_TEMP/winapi_shell_drag_drop_$($case.Id)_$($linkMode.Id).exe"
+                  $compilerArgs = @("-Wall", "-Werror", "-Werror=implicit-function-declaration")
+                  $compilerArgs += $case.Defines
+                  $compilerArgs += $linkMode.Defines
+                  $compilerArgs += @("-o", $output, $probe)
+                  $compilerArgs += $linkMode.Libraries
+
+                  & $case.Compiler @compilerArgs
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "$($case.Name) shell drag/drop probe with $($linkMode.Name) failed"
+                  }
+                  & $output
+                  if ($LASTEXITCODE -ne 0) {
+                      throw "$($case.Name) shell drag/drop probe with $($linkMode.Name) execution failed"
+                  }
+              }
+          }
+
+      - name: validate RegDeleteKeyW import with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/winapi_reg_delete_key.c"
+          $x64 = "$env:RUNNER_TEMP/winapi_reg_delete_key_x64.exe"
+          $i386 = "$env:RUNNER_TEMP/winapi_reg_delete_key_i386.exe"
+
+          & work/thirdparty/tcc/tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -o $x64 $probe -ladvapi32
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 RegDeleteKeyW conformance probe failed"
+          }
+          & $x64
+          if ($LASTEXITCODE -ne 0) {
+              throw "x64 RegDeleteKeyW conformance probe execution failed"
+          }
+
+          & work/thirdparty/tcc/i386-win32-tcc.exe `
+              -Wall -Werror `
+              -Werror=implicit-function-declaration `
+              -o $i386 $probe -ladvapi32
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 RegDeleteKeyW conformance probe failed"
+          }
+          & $i386
+          if ($LASTEXITCODE -ne 0) {
+              throw "i386 RegDeleteKeyW conformance probe execution failed"
           }
 
       - name: run shared conformance tests

--- a/0005-win32-declare-InetNtop-InetPton-family.patch
+++ b/0005-win32-declare-InetNtop-InetPton-family.patch
@@ -1,0 +1,37 @@
+win32: declare InetNtop and InetPton family
+
+InetNtopA/W and InetPtonA/W are part of the ws2_32 API starting at
+_WIN32_WINNT 0x0600. Add the missing declarations and standard
+ANSI/Unicode neutral aliases to ws2tcpip.h, preserving the WSAAPI
+calling convention on both x64 and i386.
+
+diff --git a/win32/include/winapi/ws2tcpip.h b/win32/include/winapi/ws2tcpip.h
+--- a/win32/include/winapi/ws2tcpip.h
++++ b/win32/include/winapi/ws2tcpip.h
+@@ -10,6 +10,7 @@
+ #pragma GCC system_header
+ #endif
+
++#include <_mingw_unicode.h>
+ #include <ws2ipdef.h>
+
+ struct ip_msfilter {
+@@ -384,6 +385,18 @@ WCHAR *gai_strerrorW(int);
+ #define NI_NUMERICSERV 0x08
+ #define NI_DGRAM 0x10
+
++#if (_WIN32_WINNT >= 0x0600)
++#define InetNtopA inet_ntop
++  WINSOCK_API_LINKAGE LPCWSTR WSAAPI InetNtopW(INT Family,LPCVOID pAddr,LPWSTR pStringBuf,size_t StringBufSize);
++  WINSOCK_API_LINKAGE LPCSTR WSAAPI InetNtopA(INT Family,LPCVOID pAddr,LPSTR pStringBuf,size_t StringBufSize);
++#define InetNtop __MINGW_NAME_AW(InetNtop)
++
++#define InetPtonA inet_pton
++  WINSOCK_API_LINKAGE INT WSAAPI InetPtonW(INT Family,LPCWSTR pStringBuf,PVOID pAddr);
++  WINSOCK_API_LINKAGE INT WSAAPI InetPtonA(INT Family,LPCSTR pStringBuf,PVOID pAddr);
++#define InetPton __MINGW_NAME_AW(InetPton)
++#endif
++
+ #ifdef __cplusplus
+ }
+ #endif

--- a/0006-win32-declare-shell-drag-drop-family.patch
+++ b/0006-win32-declare-shell-drag-drop-family.patch
@@ -1,0 +1,64 @@
+win32: declare shell drag-and-drop family
+
+Add the complete DragQueryFileA/W, DragQueryPoint, DragFinish, and
+DragAcceptFiles family to the minimal shellapi.h, including HDROP and
+the standard ANSI/Unicode neutral alias. Preserve WINAPI on x64 and
+i386.
+
+The cross i386 compiler cannot search the native system DLL directory.
+Ship a shell32 definition file containing both the new drag-and-drop
+exports and every shell32 export already declared by the minimal header.
+
+diff --git a/win32/include/winapi/shellapi.h b/win32/include/winapi/shellapi.h
+--- a/win32/include/winapi/shellapi.h
++++ b/win32/include/winapi/shellapi.h
+@@ -6,6 +6,8 @@
+ #ifndef _INC_SHELLAPI
+ #define _INC_SHELLAPI
+
++#include <_mingw_unicode.h>
++
+ #ifndef WINSHELLAPI
+ #if !defined(_SHELL32_)
+ #define WINSHELLAPI DECLSPEC_IMPORT
+@@ -34,6 +36,10 @@
+ extern "C" {
+ #endif
+
++  DECLARE_HANDLE(HDROP);
++
++#define DragQueryFile __MINGW_NAME_AW(DragQueryFile)
++
+ #ifdef UNICODE
+ #define ShellExecute ShellExecuteW
+ #define FindExecutable FindExecutableW
+@@ -43,6 +49,11 @@
+ #endif
+
+   /* minimal subset distributed with TinyCC. nShowCmd is at winuser.h */
++  SHSTDAPI_(UINT) DragQueryFileA(HDROP hDrop,UINT iFile,LPSTR lpszFile,UINT cch);
++  SHSTDAPI_(UINT) DragQueryFileW(HDROP hDrop,UINT iFile,LPWSTR lpszFile,UINT cch);
++  SHSTDAPI_(WINBOOL) DragQueryPoint(HDROP hDrop,POINT *ppt);
++  SHSTDAPI_(void) DragFinish(HDROP hDrop);
++  SHSTDAPI_(void) DragAcceptFiles(HWND hWnd,WINBOOL fAccept);
+   SHSTDAPI_(HINSTANCE) ShellExecuteA(HWND hwnd,LPCSTR lpOperation,LPCSTR lpFile,LPCSTR lpParameters,LPCSTR lpDirectory,INT nShowCmd);
+   SHSTDAPI_(HINSTANCE) ShellExecuteW(HWND hwnd,LPCWSTR lpOperation,LPCWSTR lpFile,LPCWSTR lpParameters,LPCWSTR lpDirectory,INT nShowCmd);
+   SHSTDAPI_(HINSTANCE) FindExecutableA(LPCSTR lpFile,LPCSTR lpDirectory,LPSTR lpResult);
+diff --git a/win32/lib/shell32.def b/win32/lib/shell32.def
+new file mode 100644
+--- /dev/null
++++ b/win32/lib/shell32.def
+@@ -0,0 +1,13 @@
++LIBRARY shell32.dll
++
++EXPORTS
++CommandLineToArgvW
++DragAcceptFiles
++DragFinish
++DragQueryFileA
++DragQueryFileW
++DragQueryPoint
++FindExecutableA
++FindExecutableW
++ShellExecuteA
++ShellExecuteW

--- a/0007-win32-declare-secure-narrow-stdio.patch
+++ b/0007-win32-declare-secure-narrow-stdio.patch
@@ -1,0 +1,19 @@
+win32: declare secure narrow stdio functions
+
+TinyCC's secure stdio header declares the wide fopen_s/freopen_s variants,
+but omits the corresponding narrow declarations even though msvcrt exports
+both symbols. Add the documented prototypes with their exact calling
+convention and parameter types.
+
+diff --git a/win32/include/sec_api/stdio_s.h b/win32/include/sec_api/stdio_s.h
+--- a/win32/include/sec_api/stdio_s.h
++++ b/win32/include/sec_api/stdio_s.h
+@@ -17,6 +17,8 @@ extern "C" {
+ #ifndef _STDIO_S_DEFINED
+ #define _STDIO_S_DEFINED
+   _CRTIMP errno_t __cdecl clearerr_s(FILE *_File);
++  _CRTIMP errno_t __cdecl fopen_s(FILE **_File,const char *_Filename,const char *_Mode);
++  _CRTIMP errno_t __cdecl freopen_s(FILE **_File,const char *_Filename,const char *_Mode,FILE *_OldFile);
+   int __cdecl fprintf_s(FILE *_File,const char *_Format,...);
+   size_t __cdecl fread_s(void *_DstBuf,size_t _DstSize,size_t _ElementSize,size_t _Count,FILE *_File);
+   _CRTIMP int __cdecl _fscanf_s_l(FILE *_File,const char *_Format,_locale_t _Locale,...);

--- a/0008-win32-fix-exp2-range-reduction.patch
+++ b/0008-win32-fix-exp2-range-reduction.patch
@@ -1,0 +1,48 @@
+win32: fix exp2 range reduction
+
+The direct exp(x * ln2) formulation loses the exact binary exponent and
+misses the binary64 overflow and subnormal boundaries.  Split x into its
+integer and fractional parts, evaluate exp only for the fraction, and scale
+the result with scalbn.
+
+Classify NaN and infinities and reject finite out-of-range values before the
+conversion to int so large inputs cannot trigger undefined behavior.  Quiet
+signaling NaNs through arithmetic, preserve underflow and directed rounding
+below the binary64 range, and route exp2l through the corrected double
+implementation because TinyCC uses the same representation for both types.
+
+diff --git a/win32/include/tcc/tcc_libm.h b/win32/include/tcc/tcc_libm.h
+--- a/win32/include/tcc/tcc_libm.h
++++ b/win32/include/tcc/tcc_libm.h
+@@ -527,11 +527,29 @@ __CRT_INLINE long double __cdecl log2l(long double x) {
+
+
+ __CRT_INLINE double __cdecl exp2(double x) {
+-  return exp(x * 0.693147180559945309);
++  union {double f; uint64_t i;} u = {.f = x};
++  uint64_t magnitude = u.i & 0x7fffffffffffffffull;
++  int exponent;
++  double fraction;
++
++  if (magnitude > 0x7ff0000000000000ull)
++    return x + x;
++  if (magnitude == 0x7ff0000000000000ull)
++    return u.i >> 63 ? 0.0 : x;
++  if (x >= 1024.0)
++    return scalbn(1.0, 1024);
++  if (x < -1075.0)
++    return scalbn(1.0, -1075);
++
++  exponent = (int)x;
++  if ((double)exponent > x)
++    --exponent;
++  fraction = x - (double)exponent;
++  return scalbn(exp(fraction * 0.693147180559945309), exponent);
+ }
+ __CRT_INLINE float __cdecl exp2f(float x) {
+   return exp(x * 0.693147180559945309);
+ }
+ __CRT_INLINE long double __cdecl exp2l(long double x) {
+-  return exp(x * 0.693147180559945309);
++  return exp2(x);
+ }

--- a/build.ps1
+++ b/build.ps1
@@ -26,6 +26,10 @@ $TccPatch1 = Join-Path $PSScriptRoot "0001-tccpe-strip-quotes-and-default-.dll-e
 $TccPatch2 = Join-Path $PSScriptRoot "0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch"
 $TccPatch3 = Join-Path $PSScriptRoot "0003-win32-declare-CreateSymbolicLink.patch"
 $TccPatch4 = Join-Path $PSScriptRoot "0004-win32-declare-WSAConnectBy-family.patch"
+$TccPatch5 = Join-Path $PSScriptRoot "0005-win32-declare-InetNtop-InetPton-family.patch"
+$TccPatch6 = Join-Path $PSScriptRoot "0006-win32-declare-shell-drag-drop-family.patch"
+$TccPatch7 = Join-Path $PSScriptRoot "0007-win32-declare-secure-narrow-stdio.patch"
+$TccPatch8 = Join-Path $PSScriptRoot "0008-win32-fix-exp2-range-reduction.patch"
 $GcPatch = Join-Path $PSScriptRoot "v-ae88ee5-tinycc-bdwgc.patch"
 $OutDir = $PSScriptRoot
 
@@ -47,6 +51,14 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "$TccPatch3 failed to apply" }
     git apply $TccPatch4
     if ($LASTEXITCODE -ne 0) { throw "$TccPatch4 failed to apply" }
+    git apply $TccPatch5
+    if ($LASTEXITCODE -ne 0) { throw "$TccPatch5 failed to apply" }
+    git apply $TccPatch6
+    if ($LASTEXITCODE -ne 0) { throw "$TccPatch6 failed to apply" }
+    git apply $TccPatch7
+    if ($LASTEXITCODE -ne 0) { throw "$TccPatch7 failed to apply" }
+    git apply $TccPatch8
+    if ($LASTEXITCODE -ne 0) { throw "$TccPatch8 failed to apply" }
 
     Set-Location win32
     & .\build-tcc.bat -clean
@@ -60,6 +72,7 @@ try {
     Copy-Item i386-win32-tcc.exe     (Join-Path $OutDir "i386-win32-tcc.exe") -Force
     Copy-Item lib\libtcc1.a           (Join-Path $OutDir "lib\libtcc1.a") -Force
     Copy-Item lib\i386-win32-libtcc1.a (Join-Path $OutDir "lib\i386-win32-libtcc1.a") -Force
+    Copy-Item lib\shell32.def          (Join-Path $OutDir "lib\shell32.def") -Force
     foreach ($f in @("bcheck.o","bt-exe.o","bt-log.o","bt-dll.o","runmain.o",
                       "i386-win32-bcheck.o","i386-win32-bt-exe.o","i386-win32-bt-log.o",
                       "i386-win32-bt-dll.o","i386-win32-runmain.o",

--- a/include/sec_api/stdio_s.h
+++ b/include/sec_api/stdio_s.h
@@ -17,6 +17,8 @@ extern "C" {
 #ifndef _STDIO_S_DEFINED
 #define _STDIO_S_DEFINED
   _CRTIMP errno_t __cdecl clearerr_s(FILE *_File);
+  _CRTIMP errno_t __cdecl fopen_s(FILE **_File,const char *_Filename,const char *_Mode);
+  _CRTIMP errno_t __cdecl freopen_s(FILE **_File,const char *_Filename,const char *_Mode,FILE *_OldFile);
   int __cdecl fprintf_s(FILE *_File,const char *_Format,...);
   size_t __cdecl fread_s(void *_DstBuf,size_t _DstSize,size_t _ElementSize,size_t _Count,FILE *_File);
   _CRTIMP int __cdecl _fscanf_s_l(FILE *_File,const char *_Format,_locale_t _Locale,...);

--- a/include/tcc/tcc_libm.h
+++ b/include/tcc/tcc_libm.h
@@ -527,13 +527,31 @@ __CRT_INLINE long double __cdecl log2l(long double x) {
 
 
 __CRT_INLINE double __cdecl exp2(double x) {
-  return exp(x * 0.693147180559945309);
+  union {double f; uint64_t i;} u = {.f = x};
+  uint64_t magnitude = u.i & 0x7fffffffffffffffull;
+  int exponent;
+  double fraction;
+
+  if (magnitude > 0x7ff0000000000000ull)
+    return x + x;
+  if (magnitude == 0x7ff0000000000000ull)
+    return u.i >> 63 ? 0.0 : x;
+  if (x >= 1024.0)
+    return scalbn(1.0, 1024);
+  if (x < -1075.0)
+    return scalbn(1.0, -1075);
+
+  exponent = (int)x;
+  if ((double)exponent > x)
+    --exponent;
+  fraction = x - (double)exponent;
+  return scalbn(exp(fraction * 0.693147180559945309), exponent);
 }
 __CRT_INLINE float __cdecl exp2f(float x) {
   return exp(x * 0.693147180559945309);
 }
 __CRT_INLINE long double __cdecl exp2l(long double x) {
-  return exp(x * 0.693147180559945309);
+  return exp2(x);
 }
 
 

--- a/include/winapi/shellapi.h
+++ b/include/winapi/shellapi.h
@@ -6,6 +6,8 @@
 #ifndef _INC_SHELLAPI
 #define _INC_SHELLAPI
 
+#include <_mingw_unicode.h>
+
 #ifndef WINSHELLAPI
 #if !defined(_SHELL32_)
 #define WINSHELLAPI DECLSPEC_IMPORT
@@ -34,6 +36,10 @@
 extern "C" {
 #endif
 
+  DECLARE_HANDLE(HDROP);
+
+#define DragQueryFile __MINGW_NAME_AW(DragQueryFile)
+
 #ifdef UNICODE
 #define ShellExecute ShellExecuteW
 #define FindExecutable FindExecutableW
@@ -43,6 +49,11 @@ extern "C" {
 #endif
 
   /* minimal subset distributed with TinyCC. nShowCmd is at winuser.h */
+  SHSTDAPI_(UINT) DragQueryFileA(HDROP hDrop,UINT iFile,LPSTR lpszFile,UINT cch);
+  SHSTDAPI_(UINT) DragQueryFileW(HDROP hDrop,UINT iFile,LPWSTR lpszFile,UINT cch);
+  SHSTDAPI_(WINBOOL) DragQueryPoint(HDROP hDrop,POINT *ppt);
+  SHSTDAPI_(void) DragFinish(HDROP hDrop);
+  SHSTDAPI_(void) DragAcceptFiles(HWND hWnd,WINBOOL fAccept);
   SHSTDAPI_(HINSTANCE) ShellExecuteA(HWND hwnd,LPCSTR lpOperation,LPCSTR lpFile,LPCSTR lpParameters,LPCSTR lpDirectory,INT nShowCmd);
   SHSTDAPI_(HINSTANCE) ShellExecuteW(HWND hwnd,LPCWSTR lpOperation,LPCWSTR lpFile,LPCWSTR lpParameters,LPCWSTR lpDirectory,INT nShowCmd);
   SHSTDAPI_(HINSTANCE) FindExecutableA(LPCSTR lpFile,LPCSTR lpDirectory,LPSTR lpResult);

--- a/include/winapi/ws2tcpip.h
+++ b/include/winapi/ws2tcpip.h
@@ -10,6 +10,7 @@
 #pragma GCC system_header
 #endif
 
+#include <_mingw_unicode.h>
 #include <ws2ipdef.h>
 
 struct ip_msfilter {
@@ -383,6 +384,18 @@ WCHAR *gai_strerrorW(int);
 #define NI_NAMEREQD 0x04
 #define NI_NUMERICSERV 0x08
 #define NI_DGRAM 0x10
+
+#if (_WIN32_WINNT >= 0x0600)
+#define InetNtopA inet_ntop
+  WINSOCK_API_LINKAGE LPCWSTR WSAAPI InetNtopW(INT Family,LPCVOID pAddr,LPWSTR pStringBuf,size_t StringBufSize);
+  WINSOCK_API_LINKAGE LPCSTR WSAAPI InetNtopA(INT Family,LPCVOID pAddr,LPSTR pStringBuf,size_t StringBufSize);
+#define InetNtop __MINGW_NAME_AW(InetNtop)
+
+#define InetPtonA inet_pton
+  WINSOCK_API_LINKAGE INT WSAAPI InetPtonW(INT Family,LPCWSTR pStringBuf,PVOID pAddr);
+  WINSOCK_API_LINKAGE INT WSAAPI InetPtonA(INT Family,LPCSTR pStringBuf,PVOID pAddr);
+#define InetPton __MINGW_NAME_AW(InetPton)
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/advapi32.def
+++ b/lib/advapi32.def
@@ -6,6 +6,7 @@ RegOpenKeyExW
 RegCloseKey
 RegCreateKeyExW
 RegDeleteKeyExW
+RegDeleteKeyW
 RegQueryValueExW
 RegSetValueExW
 RegDeleteValueW

--- a/lib/shell32.def
+++ b/lib/shell32.def
@@ -1,0 +1,13 @@
+LIBRARY shell32.dll
+
+EXPORTS
+CommandLineToArgvW
+DragAcceptFiles
+DragFinish
+DragQueryFileA
+DragQueryFileW
+DragQueryPoint
+FindExecutableA
+FindExecutableW
+ShellExecuteA
+ShellExecuteW

--- a/tests/crt_secure_freopen.c
+++ b/tests/crt_secure_freopen.c
@@ -1,0 +1,39 @@
+#include <stdio.h>
+#include <string.h>
+
+typedef errno_t (__cdecl *fopen_s_fn)(FILE **, const char *, const char *);
+typedef errno_t (__cdecl *freopen_s_fn)(FILE **, const char *, const char *, FILE *);
+
+static fopen_s_fn checked_fopen_s = fopen_s;
+static freopen_s_fn checked_freopen_s = freopen_s;
+
+int main(int argc, char **argv) {
+	static const char expected[] = "tccbin secure CRT probe\n";
+	char actual[sizeof(expected)] = {0};
+	FILE *stream = NULL;
+	FILE *reopened = NULL;
+	int result = 0;
+
+	if (argc != 2) {
+		return 2;
+	}
+	if (checked_fopen_s(&stream, argv[1], "w+") != 0 || stream == NULL) {
+		return 3;
+	}
+	if (fputs(expected, stream) == EOF) {
+		fclose(stream);
+		return 4;
+	}
+	if (checked_freopen_s(&reopened, argv[1], "r", stream) != 0 || reopened == NULL) {
+		return 5;
+	}
+	if (fgets(actual, (int) sizeof(actual), reopened) == NULL) {
+		result = 6;
+	} else if (strcmp(actual, expected) != 0) {
+		result = 7;
+	}
+	if (fclose(reopened) != 0 && result == 0) {
+		result = 8;
+	}
+	return result;
+}

--- a/tests/math_exp2_range.c
+++ b/tests/math_exp2_range.c
@@ -1,0 +1,296 @@
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+
+unsigned int _clearfp(void);
+unsigned int _controlfp(unsigned int new_value, unsigned int mask);
+unsigned int _statusfp(void);
+
+#define _SW_INEXACT 0x00000001U
+#define _SW_UNDERFLOW 0x00000002U
+#define _SW_INVALID 0x00000010U
+#define _RC_UP 0x00000200U
+#define _MCW_RC 0x00000300U
+
+typedef union {
+	double value;
+	uint64_t bits;
+} double_bits;
+
+typedef enum {
+	TEST_FP_ZERO,
+	TEST_FP_SUBNORMAL,
+	TEST_FP_NORMAL,
+	TEST_FP_INFINITY,
+	TEST_FP_QNAN,
+	TEST_FP_SNAN
+} test_fp_class;
+
+typedef struct {
+	double input;
+	double expected;
+} exp2_case;
+
+static const double vf_[] = {
+	4.9790119248836735e+00,
+	7.7388724745781045e+00,
+	-2.7688005719200159e-01,
+	-5.0106036182710749e+00,
+	9.6362937071984173e+00,
+	2.9263772392439646e+00,
+	5.2290834314593066e+00,
+	2.7279399104360102e+00,
+	1.8253080916808550e+00,
+	-8.6859247685756013e+00,
+};
+
+static const double exp2_[] = {
+	3.1537839463286288034313104e+01,
+	2.1361549283756232296144849e+02,
+	8.2537402562185562902577219e-01,
+	3.1021158628740294833424229e-02,
+	7.9581744110252191462569661e+02,
+	7.6019905892596359262696423e+00,
+	3.7506882048388096973183084e+01,
+	6.6250893439173561733216375e+00,
+	3.5438267900243941544605339e+00,
+	2.4281533133513300984289196e-03,
+};
+
+static uint64_t bits_of(double value)
+{
+	double_bits converted;
+	converted.value = value;
+	return converted.bits;
+}
+
+static double value_from_bits(uint64_t bits)
+{
+	double_bits converted;
+	converted.bits = bits;
+	return converted.value;
+}
+
+static test_fp_class class_of_bits(uint64_t bits)
+{
+	uint64_t magnitude = bits & 0x7fffffffffffffffULL;
+	uint64_t fraction = magnitude & 0x000fffffffffffffULL;
+
+	if (magnitude == 0)
+		return TEST_FP_ZERO;
+	if ((magnitude & 0x7ff0000000000000ULL) == 0)
+		return TEST_FP_SUBNORMAL;
+	if ((magnitude & 0x7ff0000000000000ULL) !=
+		0x7ff0000000000000ULL)
+		return TEST_FP_NORMAL;
+	if (fraction == 0)
+		return TEST_FP_INFINITY;
+	if (fraction & 0x0008000000000000ULL)
+		return TEST_FP_QNAN;
+	return TEST_FP_SNAN;
+}
+
+static int strict_same_class(double actual, double expected)
+{
+	uint64_t actual_bits = bits_of(actual);
+	uint64_t expected_bits = bits_of(expected);
+
+	return class_of_bits(actual_bits) == class_of_bits(expected_bits) &&
+		(actual_bits >> 63) == (expected_bits >> 63);
+}
+
+static int strict_close(double actual, double expected, double tolerance)
+{
+	double difference;
+	test_fp_class expected_class;
+
+	if (!strict_same_class(actual, expected))
+		return 0;
+	expected_class = class_of_bits(bits_of(expected));
+	if (expected_class == TEST_FP_ZERO ||
+		expected_class == TEST_FP_INFINITY ||
+		expected_class == TEST_FP_QNAN ||
+		expected_class == TEST_FP_SNAN)
+		return 1;
+	difference = actual - expected;
+	if (difference < 0.0)
+		difference = -difference;
+	if (expected != 0.0) {
+		tolerance *= expected;
+		if (tolerance < 0.0)
+			tolerance = -tolerance;
+	}
+	return difference <= tolerance;
+}
+
+static double exact_power_of_two(int exponent)
+{
+	if (exponent < -1022)
+		return value_from_bits(1ULL << (exponent + 1074));
+	return value_from_bits((uint64_t) (exponent + 1023) << 52);
+}
+
+int main(void)
+{
+	exp2_case special_cases[] = {
+		{-2000.0, 0.0},
+		{2000.0, value_from_bits(0x7ff0000000000000ULL)},
+		{value_from_bits(0x7ff0000000000000ULL),
+			value_from_bits(0x7ff0000000000000ULL)},
+		{value_from_bits(0x7ff8000000000000ULL),
+			value_from_bits(0x7ff8000000000000ULL)},
+		{1024.0, value_from_bits(0x7ff0000000000000ULL)},
+		{-1.07399999999999e+03, 5e-324},
+		{3.725290298461915e-09, 1.0000000025821745},
+	};
+	volatile double_bits signaling_nan;
+	volatile double underflow_input = -2000.0;
+	volatile long double exp2l_input = 1024.0L;
+	volatile double_bits below_1024;
+	unsigned int special_failures = 0;
+	unsigned int range_failures = 0;
+	unsigned int diagnostic_failures = 0;
+	unsigned int saved_control;
+	unsigned int restored_control;
+	unsigned int status;
+	unsigned int i;
+	int first_failed_exponent = 0;
+	double first_actual = 0.0;
+	double first_expected = 0.0;
+	int exponent;
+
+	for (i = 0; i < sizeof(special_cases) / sizeof(special_cases[0]); i++) {
+		double actual = exp2(special_cases[i].input);
+
+		if (!strict_close(actual, special_cases[i].expected, 4e-16)) {
+			special_failures++;
+			fprintf(stderr,
+				"exp2 special case %u failed: input=%016llx expected=%016llx actual=%016llx\n",
+				i,
+				(unsigned long long) bits_of(special_cases[i].input),
+				(unsigned long long) bits_of(special_cases[i].expected),
+				(unsigned long long) bits_of(actual));
+		}
+	}
+
+	for (exponent = -1074; exponent < 1024; exponent++) {
+		double expected = exact_power_of_two(exponent);
+		double actual = exp2((double) exponent);
+
+		if (bits_of(actual) != bits_of(expected)) {
+			if (range_failures == 0) {
+				first_failed_exponent = exponent;
+				first_actual = actual;
+				first_expected = expected;
+			}
+			range_failures++;
+		}
+	}
+	if (range_failures != 0) {
+		fprintf(stderr,
+			"exp2 integer range failed %u times; first n=%d expected=%016llx actual=%016llx\n",
+			range_failures,
+			first_failed_exponent,
+			(unsigned long long) bits_of(first_expected),
+			(unsigned long long) bits_of(first_actual));
+	}
+
+	signaling_nan.bits = 0x7ff0000000000001ULL;
+	_clearfp();
+	{
+		double actual = exp2(signaling_nan.value);
+
+		status = _statusfp();
+		if (class_of_bits(bits_of(actual)) != TEST_FP_QNAN) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 sNaN quieting failed: input=7ff0000000000001 actual=%016llx class=%u\n",
+				(unsigned long long) bits_of(actual),
+				(unsigned int) class_of_bits(bits_of(actual)));
+		}
+		if ((status & _SW_INVALID) == 0) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 sNaN invalid status failed: status=%08x expected-mask=%08x\n",
+				status, _SW_INVALID);
+		}
+	}
+	_clearfp();
+
+	saved_control = _controlfp(0, 0);
+	_controlfp(_RC_UP, _MCW_RC);
+	_clearfp();
+	{
+		double actual = exp2(underflow_input);
+
+		status = _statusfp();
+		if (bits_of(actual) != 1ULL) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 upward underflow value failed: input=-2000 expected=0000000000000001 actual=%016llx\n",
+				(unsigned long long) bits_of(actual));
+		}
+		if ((status & _SW_UNDERFLOW) == 0) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 upward underflow status failed: status=%08x expected-mask=%08x\n",
+				status, _SW_UNDERFLOW);
+		}
+		if ((status & _SW_INEXACT) == 0) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 upward inexact status failed: status=%08x expected-mask=%08x\n",
+				status, _SW_INEXACT);
+		}
+	}
+	restored_control = _controlfp(saved_control, _MCW_RC);
+	if ((restored_control & _MCW_RC) != (saved_control & _MCW_RC)) {
+		diagnostic_failures++;
+		fprintf(stderr,
+			"floating-point rounding restoration failed: saved=%08x restored=%08x\n",
+			saved_control, restored_control);
+	}
+	_clearfp();
+
+	{
+		double actual = (double) exp2l(exp2l_input);
+
+		if (bits_of(actual) != 0x7ff0000000000000ULL) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2l overflow boundary failed: input=1024 expected=7ff0000000000000 actual=%016llx\n",
+				(unsigned long long) bits_of(actual));
+		}
+	}
+
+	for (i = 0; i < sizeof(vf_) / sizeof(vf_[0]); i++) {
+		double actual = exp2(vf_[i]);
+
+		if (!strict_close(actual, exp2_[i], 1e-9)) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 V fractional case %u failed: input=%.17g expected=%.17g actual=%.17g expected-class=%u actual-class=%u\n",
+				i, vf_[i], exp2_[i], actual,
+				(unsigned int) class_of_bits(bits_of(exp2_[i])),
+				(unsigned int) class_of_bits(bits_of(actual)));
+		}
+	}
+
+	below_1024.bits = 0x408fffffffffffffULL;
+	{
+		double actual = exp2(below_1024.value);
+		uint64_t actual_bits = bits_of(actual);
+
+		if (class_of_bits(actual_bits) != TEST_FP_NORMAL ||
+			(actual_bits >> 63) != 0) {
+			diagnostic_failures++;
+			fprintf(stderr,
+				"exp2 predecessor of 1024 failed: input=408fffffffffffff actual=%016llx class=%u\n",
+				(unsigned long long) actual_bits,
+				(unsigned int) class_of_bits(actual_bits));
+		}
+	}
+
+	return special_failures != 0 || range_failures != 0 ||
+		diagnostic_failures != 0;
+}

--- a/tests/winapi_inet_ntop_pton.c
+++ b/tests/winapi_inet_ntop_pton.c
@@ -1,0 +1,62 @@
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+typedef LPCSTR (WSAAPI *inet_ntop_a_fn)(INT Family,LPCVOID pAddr,LPSTR pStringBuf,size_t StringBufSize);
+typedef LPCWSTR (WSAAPI *inet_ntop_w_fn)(INT Family,LPCVOID pAddr,LPWSTR pStringBuf,size_t StringBufSize);
+typedef INT (WSAAPI *inet_pton_a_fn)(INT Family,LPCSTR pStringBuf,PVOID pAddr);
+typedef INT (WSAAPI *inet_pton_w_fn)(INT Family,LPCWSTR pStringBuf,PVOID pAddr);
+
+#ifdef UNICODE
+typedef inet_ntop_w_fn inet_ntop_neutral_fn;
+typedef inet_pton_w_fn inet_pton_neutral_fn;
+#define EXPECTED_INET_NTOP InetNtopW
+#define EXPECTED_INET_PTON InetPtonW
+#else
+typedef inet_ntop_a_fn inet_ntop_neutral_fn;
+typedef inet_pton_a_fn inet_pton_neutral_fn;
+#define EXPECTED_INET_NTOP InetNtopA
+#define EXPECTED_INET_PTON InetPtonA
+#endif
+
+static volatile inet_ntop_a_fn inet_ntop_ptr = inet_ntop;
+static volatile inet_ntop_a_fn inet_ntop_a_ptr = InetNtopA;
+static volatile inet_ntop_w_fn inet_ntop_w_ptr = InetNtopW;
+static volatile inet_ntop_neutral_fn inet_ntop_neutral_ptr = InetNtop;
+static volatile inet_pton_a_fn inet_pton_ptr = inet_pton;
+static volatile inet_pton_a_fn inet_pton_a_ptr = InetPtonA;
+static volatile inet_pton_w_fn inet_pton_w_ptr = InetPtonW;
+static volatile inet_pton_neutral_fn inet_pton_neutral_ptr = InetPton;
+
+static int probe_calls(void)
+{
+    IN_ADDR ansi_address = {0};
+    IN_ADDR wide_address = {0};
+    char ansi_text[INET_ADDRSTRLEN];
+    WCHAR wide_text[INET_ADDRSTRLEN];
+
+    if (inet_pton(AF_INET,"127.0.0.1",&ansi_address) != 1)
+        return 2;
+    if (inet_ntop(AF_INET,&ansi_address,ansi_text,sizeof(ansi_text)) == 0)
+        return 3;
+    if (InetPtonW(AF_INET,L"127.0.0.1",&wide_address) != 1)
+        return 4;
+    if (InetNtopW(AF_INET,&wide_address,wide_text,sizeof(wide_text) / sizeof(wide_text[0])) == 0)
+        return 5;
+    return 0;
+}
+
+int main(void)
+{
+    if (inet_ntop_ptr == 0 ||
+        inet_ntop_a_ptr != inet_ntop_ptr ||
+        inet_ntop_w_ptr == 0 ||
+        inet_ntop_neutral_ptr != EXPECTED_INET_NTOP ||
+        inet_pton_ptr == 0 ||
+        inet_pton_a_ptr != inet_pton_ptr ||
+        inet_pton_w_ptr == 0 ||
+        inet_pton_neutral_ptr != EXPECTED_INET_PTON)
+        return 1;
+    return probe_calls();
+}

--- a/tests/winapi_reg_delete_key.c
+++ b/tests/winapi_reg_delete_key.c
@@ -1,0 +1,11 @@
+#include <windows.h>
+#include <winreg.h>
+
+typedef LONG (WINAPI *reg_delete_key_w_fn)(HKEY hKey,LPCWSTR lpSubKey);
+
+static volatile reg_delete_key_w_fn reg_delete_key_w_ptr = RegDeleteKeyW;
+
+int main(void)
+{
+    return reg_delete_key_w_ptr == 0;
+}

--- a/tests/winapi_shell_drag_drop.c
+++ b/tests/winapi_shell_drag_drop.c
@@ -1,0 +1,68 @@
+#include <windows.h>
+#include <shellapi.h>
+
+#ifndef TCCBIN_NO_SHELL32_PRAGMA
+#pragma comment(lib,"shell32")
+#endif
+
+_Static_assert(sizeof(HDROP) == sizeof(void *),"HDROP must be pointer-sized");
+_Static_assert(sizeof(POINT) == 8,"POINT must contain two 32-bit LONG values");
+_Static_assert(sizeof(WINBOOL) == 4,"WINBOOL must be 32-bit");
+
+typedef UINT (WINAPI *drag_query_file_a_fn)(HDROP hDrop,UINT iFile,LPSTR lpszFile,UINT cch);
+typedef UINT (WINAPI *drag_query_file_w_fn)(HDROP hDrop,UINT iFile,LPWSTR lpszFile,UINT cch);
+typedef WINBOOL (WINAPI *drag_query_point_fn)(HDROP hDrop,POINT *ppt);
+typedef void (WINAPI *drag_finish_fn)(HDROP hDrop);
+typedef void (WINAPI *drag_accept_files_fn)(HWND hWnd,WINBOOL fAccept);
+typedef HINSTANCE (WINAPI *shell_execute_a_fn)(HWND hwnd,LPCSTR lpOperation,LPCSTR lpFile,LPCSTR lpParameters,LPCSTR lpDirectory,INT nShowCmd);
+typedef HINSTANCE (WINAPI *shell_execute_w_fn)(HWND hwnd,LPCWSTR lpOperation,LPCWSTR lpFile,LPCWSTR lpParameters,LPCWSTR lpDirectory,INT nShowCmd);
+typedef HINSTANCE (WINAPI *find_executable_a_fn)(LPCSTR lpFile,LPCSTR lpDirectory,LPSTR lpResult);
+typedef HINSTANCE (WINAPI *find_executable_w_fn)(LPCWSTR lpFile,LPCWSTR lpDirectory,LPWSTR lpResult);
+typedef LPWSTR *(WINAPI *command_line_to_argv_w_fn)(LPCWSTR lpCmdLine,int *pNumArgs);
+
+#ifdef UNICODE
+typedef drag_query_file_w_fn drag_query_file_neutral_fn;
+typedef shell_execute_w_fn shell_execute_neutral_fn;
+typedef find_executable_w_fn find_executable_neutral_fn;
+#define EXPECTED_DRAG_QUERY_FILE DragQueryFileW
+#define EXPECTED_SHELL_EXECUTE ShellExecuteW
+#define EXPECTED_FIND_EXECUTABLE FindExecutableW
+#else
+typedef drag_query_file_a_fn drag_query_file_neutral_fn;
+typedef shell_execute_a_fn shell_execute_neutral_fn;
+typedef find_executable_a_fn find_executable_neutral_fn;
+#define EXPECTED_DRAG_QUERY_FILE DragQueryFileA
+#define EXPECTED_SHELL_EXECUTE ShellExecuteA
+#define EXPECTED_FIND_EXECUTABLE FindExecutableA
+#endif
+
+static volatile drag_query_file_a_fn drag_query_file_a_ptr = DragQueryFileA;
+static volatile drag_query_file_w_fn drag_query_file_w_ptr = DragQueryFileW;
+static volatile drag_query_file_neutral_fn drag_query_file_ptr = DragQueryFile;
+static volatile drag_query_point_fn drag_query_point_ptr = DragQueryPoint;
+static volatile drag_finish_fn drag_finish_ptr = DragFinish;
+static volatile drag_accept_files_fn drag_accept_files_ptr = DragAcceptFiles;
+static volatile shell_execute_a_fn shell_execute_a_ptr = ShellExecuteA;
+static volatile shell_execute_w_fn shell_execute_w_ptr = ShellExecuteW;
+static volatile shell_execute_neutral_fn shell_execute_ptr = ShellExecute;
+static volatile find_executable_a_fn find_executable_a_ptr = FindExecutableA;
+static volatile find_executable_w_fn find_executable_w_ptr = FindExecutableW;
+static volatile find_executable_neutral_fn find_executable_ptr = FindExecutable;
+static volatile command_line_to_argv_w_fn command_line_to_argv_w_ptr = CommandLineToArgvW;
+
+int main(void)
+{
+    return drag_query_file_a_ptr == 0 ||
+           drag_query_file_w_ptr == 0 ||
+           drag_query_file_ptr != EXPECTED_DRAG_QUERY_FILE ||
+           drag_query_point_ptr == 0 ||
+           drag_finish_ptr == 0 ||
+           drag_accept_files_ptr == 0 ||
+           shell_execute_a_ptr == 0 ||
+           shell_execute_w_ptr == 0 ||
+           shell_execute_ptr != EXPECTED_SHELL_EXECUTE ||
+           find_executable_a_ptr == 0 ||
+           find_executable_w_ptr == 0 ||
+           find_executable_ptr != EXPECTED_FIND_EXECUTABLE ||
+           command_line_to_argv_w_ptr == 0;
+}


### PR DESCRIPTION
## Summary

This updates the Windows TinyCC bundle used by V to restore missing API coverage and correct `exp2` behavior.

## Changes

- add the missing `InetNtop` / `InetPton` declarations
- add shell drag-and-drop declarations and imports
- restore the `RegDeleteKeyW` import
- add the missing `fopen_s` / `freopen_s` declarations
- apply the new compatibility patches from `build.ps1`
- fix `exp2` range reduction across the binary64 normal and subnormal ranges
- handle NaN, infinity, overflow, directed underflow, and `exp2l` consistently
- add native C regression coverage for both x64 and i386 TinyCC

The math change is intentionally limited to the `exp2` / `exp2l` behavior exercised by V. `exp2f` and the wider CRT math layer are unchanged.

## Validation

- rebuilt `tcc.exe`, `libtcc.dll`, `i386-win32-tcc.exe`, and `libgc.a`
- passed the Windows native x64 and i386 API probes
- passed the x64 and i386 `exp2` boundary, classification, rounding, and V math vector tests
- passed the shared tccbin conformance suite
- passed downstream V checks for pkg-config isolation, strict no-fallback tools, the pure V math module, and the multiwindow runtime contract