### PR TITLE
windows: fix strict synchapi alias redefinitions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -197,6 +197,54 @@ jobs:
               throw "i386 Unicode WinAPI conformance probe failed"
           }
 
+      - name: validate synchapi aliases with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/winapi_synchapi_aliases.c"
+          $architectures = @(
+              @{ Id = "x64"; Name = "x64"; Compiler = "work/thirdparty/tcc/tcc.exe" },
+              @{ Id = "i386"; Name = "i386"; Compiler = "work/thirdparty/tcc/i386-win32-tcc.exe" }
+          )
+          $characterSets = @(
+              @{ Id = "ansi"; Name = "ANSI"; Defines = @() },
+              @{ Id = "unicode"; Name = "Unicode"; Defines = @("-DUNICODE", "-D_UNICODE") }
+          )
+          $includeModes = @(
+              @{ Id = "windows_first"; Name = "windows.h-first"; Defines = @() },
+              @{ Id = "reverse"; Name = "windef.h-synchapi.h-winbase.h"; Defines = @("-DTCCBIN_SYNCHAPI_REVERSE_INCLUDE_ORDER") }
+          )
+
+          foreach ($architecture in $architectures) {
+              foreach ($characterSet in $characterSets) {
+                  foreach ($includeMode in $includeModes) {
+                      $token = [guid]::NewGuid().ToString("N")
+                      $executable = Join-Path $env:RUNNER_TEMP "winapi_synchapi_aliases_$($architecture.Id)_$($characterSet.Id)_$($includeMode.Id)_$token.exe"
+                      try {
+                          $compilerArgs = @(
+                              "-Wall",
+                              "-Wextra",
+                              "-Werror",
+                              "-Werror=implicit-function-declaration"
+                          )
+                          $compilerArgs += $characterSet.Defines
+                          $compilerArgs += $includeMode.Defines
+                          $compilerArgs += @("-o", $executable, $probe)
+
+                          & $architecture.Compiler @compilerArgs
+                          if ($LASTEXITCODE -ne 0) {
+                              throw "$($architecture.Name) $($characterSet.Name) $($includeMode.Name) synchapi probe failed to compile or link"
+                          }
+                          & $executable
+                          if ($LASTEXITCODE -ne 0) {
+                              throw "$($architecture.Name) $($characterSet.Name) $($includeMode.Name) synchapi probe failed at runtime"
+                          }
+                      } finally {
+                          Remove-Item -LiteralPath $executable -Force -ErrorAction SilentlyContinue
+                      }
+                  }
+              }
+          }
+
       - name: validate WSAConnectBy WinAPI declarations with x64 and i386 TCC
         shell: pwsh
         run: |

--- a/include/winapi/synchapi.h
+++ b/include/winapi/synchapi.h
@@ -10,7 +10,6 @@ extern "C" {
 #endif
 
 #include <_mingw_unicode.h>
-#define CreateEvent __MINGW_NAME_AW(CreateEvent)
 
 #define SRWLOCK_INIT RTL_SRWLOCK_INIT
 
@@ -114,7 +113,13 @@ typedef DWORD (WINAPI *PRTL_RUN_ONCE_INIT_FN)(PRTL_RUN_ONCE, PVOID, PVOID *);
 #define OpenMutex OpenMutexW
 #define OpenSemaphore OpenSemaphoreW
 #endif
-#define OpenEvent __MINGW_NAME_AW(OpenEvent)
+#ifndef OpenEvent
+#ifdef UNICODE
+#define OpenEvent OpenEventW
+#else
+#define OpenEvent OpenEventA
+#endif
+#endif
 
   typedef VOID (APIENTRY *PTIMERAPCROUTINE) (LPVOID lpArgToCompletionRoutine, DWORD dwTimerLowValue, DWORD dwTimerHighValue);
 
@@ -164,8 +169,20 @@ typedef DWORD (WINAPI *PRTL_RUN_ONCE_INIT_FN)(PRTL_RUN_ONCE, PVOID, PVOID *);
   WINBOOL WINAPI SetWaitableTimerEx (HANDLE hTimer, const LARGE_INTEGER *lpDueTime, LONG lPeriod, PTIMERAPCROUTINE pfnCompletionRoutine, LPVOID lpArgToCompletionRoutine, PREASON_CONTEXT WakeContext, ULONG TolerableDelay);
 #endif
 
-#define CreateMutex __MINGW_NAME_AW(CreateMutex)
-#define CreateEvent __MINGW_NAME_AW(CreateEvent)
+#ifndef CreateMutex
+#ifdef UNICODE
+#define CreateMutex CreateMutexW
+#else
+#define CreateMutex CreateMutexA
+#endif
+#endif
+#ifndef CreateEvent
+#ifdef UNICODE
+#define CreateEvent CreateEventW
+#else
+#define CreateEvent CreateEventA
+#endif
+#endif
 
 #ifdef UNICODE
 #define OpenWaitableTimer OpenWaitableTimerW

--- a/tests/winapi_synchapi_aliases.c
+++ b/tests/winapi_synchapi_aliases.c
@@ -1,0 +1,53 @@
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#ifdef TCCBIN_SYNCHAPI_REVERSE_INCLUDE_ORDER
+#include <excpt.h>
+#include <stdarg.h>
+#include <windef.h>
+#define WINBASEAPI DECLSPEC_IMPORT
+typedef struct _SECURITY_ATTRIBUTES *LPSECURITY_ATTRIBUTES;
+typedef PRTL_CRITICAL_SECTION PCRITICAL_SECTION;
+typedef PRTL_CRITICAL_SECTION LPCRITICAL_SECTION;
+#include <synchapi.h>
+#include <winbase.h>
+#else
+#include <windows.h>
+#include <synchapi.h>
+#endif
+
+#ifndef OpenEvent
+#error OpenEvent alias is missing
+#endif
+#ifndef CreateMutex
+#error CreateMutex alias is missing
+#endif
+#ifndef CreateEvent
+#error CreateEvent alias is missing
+#endif
+
+#ifdef UNICODE
+typedef HANDLE (WINAPI *open_event_alias_fn)(DWORD,WINBOOL,LPCWSTR);
+typedef HANDLE (WINAPI *create_mutex_alias_fn)(LPSECURITY_ATTRIBUTES,WINBOOL,LPCWSTR);
+typedef HANDLE (WINAPI *create_event_alias_fn)(LPSECURITY_ATTRIBUTES,WINBOOL,WINBOOL,LPCWSTR);
+#define EXPECTED_OPEN_EVENT OpenEventW
+#define EXPECTED_CREATE_MUTEX CreateMutexW
+#define EXPECTED_CREATE_EVENT CreateEventW
+#else
+typedef HANDLE (WINAPI *open_event_alias_fn)(DWORD,WINBOOL,LPCSTR);
+typedef HANDLE (WINAPI *create_mutex_alias_fn)(LPSECURITY_ATTRIBUTES,WINBOOL,LPCSTR);
+typedef HANDLE (WINAPI *create_event_alias_fn)(LPSECURITY_ATTRIBUTES,WINBOOL,WINBOOL,LPCSTR);
+#define EXPECTED_OPEN_EVENT OpenEventA
+#define EXPECTED_CREATE_MUTEX CreateMutexA
+#define EXPECTED_CREATE_EVENT CreateEventA
+#endif
+
+static volatile open_event_alias_fn open_event_alias = OpenEvent;
+static volatile create_mutex_alias_fn create_mutex_alias = CreateMutex;
+static volatile create_event_alias_fn create_event_alias = CreateEvent;
+
+int main(void)
+{
+    return open_event_alias != EXPECTED_OPEN_EVENT ||
+           create_mutex_alias != EXPECTED_CREATE_MUTEX ||
+           create_event_alias != EXPECTED_CREATE_EVENT;
+}


### PR DESCRIPTION
## Summary

Fix strict-warning macro redefinitions between `synchapi.h` and `winbase.h` for `OpenEvent`, `CreateMutex`, and `CreateEvent`.

Remove the premature duplicate `CreateEvent` alias, guard the remaining aliases, and use ANSI/Unicode mappings that match `winbase.h`.

## Cause

The supplemental tccbin `synchapi.h` defined these aliases with tokens different from `winbase.h`. Including both headers under `-Werror` therefore produced macro-redefinition errors.

The same header problem exists with both the old and current TinyCC bundles, so it was not introduced by the recent TinyCC update.

## Validation

The complete native Windows tccbin workflow passed, including:

- x64 and i386
- ANSI and Unicode
- both supported header inclusion orders
- strict `-Wall -Wextra -Werror` compilation
- compile, link, and runtime verification