### PR TITLE
windows: declare and test CancelIoEx

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -197,6 +197,30 @@ jobs:
               throw "i386 Unicode WinAPI conformance probe failed"
           }
 
+      - name: validate CancelIoEx ABI with x64 and i386 TCC
+        shell: pwsh
+        run: |
+          $probe = "work/thirdparty/tcc/tests/winapi_cancel_io_ex.c"
+          $cases = @(
+              @{ Id = "x64"; Compiler = "work/thirdparty/tcc/tcc.exe" },
+              @{ Id = "i386"; Compiler = "work/thirdparty/tcc/i386-win32-tcc.exe" }
+          )
+
+          foreach ($case in $cases) {
+              $executable = "$env:RUNNER_TEMP/winapi_cancel_io_ex_$($case.Id).exe"
+              & $case.Compiler `
+                  -Wall -Wextra -Werror `
+                  -Werror=implicit-function-declaration `
+                  -o $executable $probe
+              if ($LASTEXITCODE -ne 0) {
+                  throw "$($case.Id) CancelIoEx ABI probe failed to compile"
+              }
+              & $executable
+              if ($LASTEXITCODE -ne 0) {
+                  throw "$($case.Id) CancelIoEx ABI probe failed at runtime"
+              }
+          }
+
       - name: validate synchapi aliases with x64 and i386 TCC
         shell: pwsh
         run: |

--- a/0009-win32-declare-CancelIoEx.patch
+++ b/0009-win32-declare-CancelIoEx.patch
@@ -1,0 +1,31 @@
+win32: declare and export CancelIoEx
+
+CancelIoEx is available from Windows Vista onward. Add its gated declaration
+with the WINAPI calling convention and add its kernel32 export so builds from
+the pinned TinyCC source retain the correct ABI on both x64 and i386.
+
+diff --git a/win32/include/winapi/winbase.h b/win32/include/winapi/winbase.h
+--- a/win32/include/winapi/winbase.h
++++ b/win32/include/winapi/winbase.h
+@@ -2420,6 +2420,9 @@ extern "C" {
+   WINBASEAPI WINBOOL WINAPI GetVolumeInformationA(LPCSTR lpRootPathName,LPSTR lpVolumeNameBuffer,DWORD nVolumeNameSize,LPDWORD lpVolumeSerialNumber,LPDWORD lpMaximumComponentLength,LPDWORD lpFileSystemFlags,LPSTR lpFileSystemNameBuffer,DWORD nFileSystemNameSize);
+   WINBASEAPI WINBOOL WINAPI GetVolumeInformationW(LPCWSTR lpRootPathName,LPWSTR lpVolumeNameBuffer,DWORD nVolumeNameSize,LPDWORD lpVolumeSerialNumber,LPDWORD lpMaximumComponentLength,LPDWORD lpFileSystemFlags,LPWSTR lpFileSystemNameBuffer,DWORD nFileSystemNameSize);
+   WINBASEAPI WINBOOL WINAPI CancelIo(HANDLE hFile);
++#if _WIN32_WINNT >= 0x0600
++  WINBASEAPI WINBOOL WINAPI CancelIoEx(HANDLE hFile,LPOVERLAPPED lpOverlapped);
++#endif
+   WINADVAPI WINBOOL WINAPI ClearEventLogA(HANDLE hEventLog,LPCSTR lpBackupFileName);
+   WINADVAPI WINBOOL WINAPI ClearEventLogW(HANDLE hEventLog,LPCWSTR lpBackupFileName);
+   WINADVAPI WINBOOL WINAPI BackupEventLogA(HANDLE hEventLog,LPCSTR lpBackupFileName);
+
+diff --git a/win32/lib/kernel32.def b/win32/lib/kernel32.def
+--- a/win32/lib/kernel32.def
++++ b/win32/lib/kernel32.def
+@@ -40,6 +40,7 @@ Callback64
+ Callback8
+ CancelDeviceWakeupRequest
+ CancelIo
++CancelIoEx
+ CancelWaitableTimer
+ ClearCommBreak
+ ClearCommError

--- a/build.ps1
+++ b/build.ps1
@@ -30,6 +30,7 @@ $TccPatch5 = Join-Path $PSScriptRoot "0005-win32-declare-InetNtop-InetPton-famil
 $TccPatch6 = Join-Path $PSScriptRoot "0006-win32-declare-shell-drag-drop-family.patch"
 $TccPatch7 = Join-Path $PSScriptRoot "0007-win32-declare-secure-narrow-stdio.patch"
 $TccPatch8 = Join-Path $PSScriptRoot "0008-win32-fix-exp2-range-reduction.patch"
+$TccPatch9 = Join-Path $PSScriptRoot "0009-win32-declare-CancelIoEx.patch"
 $GcPatch = Join-Path $PSScriptRoot "v-ae88ee5-tinycc-bdwgc.patch"
 $OutDir = $PSScriptRoot
 
@@ -59,6 +60,8 @@ try {
     if ($LASTEXITCODE -ne 0) { throw "$TccPatch7 failed to apply" }
     git apply $TccPatch8
     if ($LASTEXITCODE -ne 0) { throw "$TccPatch8 failed to apply" }
+    git apply $TccPatch9
+    if ($LASTEXITCODE -ne 0) { throw "$TccPatch9 failed to apply" }
 
     Set-Location win32
     & .\build-tcc.bat -clean

--- a/include/winapi/winbase.h
+++ b/include/winapi/winbase.h
@@ -2420,6 +2420,9 @@ extern "C" {
   WINBASEAPI WINBOOL WINAPI GetVolumeInformationA(LPCSTR lpRootPathName,LPSTR lpVolumeNameBuffer,DWORD nVolumeNameSize,LPDWORD lpVolumeSerialNumber,LPDWORD lpMaximumComponentLength,LPDWORD lpFileSystemFlags,LPSTR lpFileSystemNameBuffer,DWORD nFileSystemNameSize);
   WINBASEAPI WINBOOL WINAPI GetVolumeInformationW(LPCWSTR lpRootPathName,LPWSTR lpVolumeNameBuffer,DWORD nVolumeNameSize,LPDWORD lpVolumeSerialNumber,LPDWORD lpMaximumComponentLength,LPDWORD lpFileSystemFlags,LPWSTR lpFileSystemNameBuffer,DWORD nFileSystemNameSize);
   WINBASEAPI WINBOOL WINAPI CancelIo(HANDLE hFile);
+#if _WIN32_WINNT >= 0x0600
+  WINBASEAPI WINBOOL WINAPI CancelIoEx(HANDLE hFile,LPOVERLAPPED lpOverlapped);
+#endif
   WINADVAPI WINBOOL WINAPI ClearEventLogA(HANDLE hEventLog,LPCSTR lpBackupFileName);
   WINADVAPI WINBOOL WINAPI ClearEventLogW(HANDLE hEventLog,LPCWSTR lpBackupFileName);
   WINADVAPI WINBOOL WINAPI BackupEventLogA(HANDLE hEventLog,LPCSTR lpBackupFileName);

--- a/tests/winapi_cancel_io_ex.c
+++ b/tests/winapi_cancel_io_ex.c
@@ -1,0 +1,12 @@
+#define WINVER 0x0600
+#define _WIN32_WINNT 0x0600
+#include <windows.h>
+
+typedef WINBOOL (WINAPI *cancel_io_ex_fn)(HANDLE, LPOVERLAPPED);
+
+static cancel_io_ex_fn checked_cancel_io_ex = CancelIoEx;
+
+int main(void)
+{
+    return checked_cancel_io_ex == NULL;
+}


### PR DESCRIPTION
## Summary

- Add the Vista-gated `CancelIoEx` declaration with the correct `WINAPI` signature.
- Apply the declaration and `kernel32` export when rebuilding the pinned TinyCC source.
- Add a strict ABI regression test for both x64 and i386 TCC.

## Validation

The Windows build-and-test workflow passed completely, including the TinyCC rebuild, strict x64/i386 `CancelIoEx` probes, secure CRT tests, WinAPI tests, and the shared conformance suite.