### PR TITLE
freebsd-amd64: reject exit-0 in the etext/end XFAIL signature check

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -251,8 +251,14 @@ jobs:
             # pullrequestreview-4781865117 on vlang/tccbin#75). A POSIX
             # shell reports a signal-terminated process as exit code
             # 128+signal; reject those instead of treating any nonzero
-            # exit as "the expected compile-error status".
-            if [ "$2" -gt 128 ]; then
+            # exit as "the expected compile-error status". Also reject
+            # exit 0: a changed tcc.exe could start printing this same
+            # diagnostic as noise while still reporting overall success
+            # - the text alone isn't proof the compile actually failed
+            # (Codex pullrequestreview-4783389496 on the sibling
+            # macos-amd64 workflow, vlang/tccbin#74, same class of gap
+            # here).
+            if [ "$2" -eq 0 ] || [ "$2" -gt 128 ]; then
               return 1
             fi
             case "$1" in


### PR DESCRIPTION
Follow-up to #75. That PR merged before a Codex finding on the sibling
macos-amd64 workflow (pullrequestreview-4783389496, #74) was ported over
here, so it never made it in.

`is_known_etext_end` only rejected signal-terminated exits (>128), never
exit 0. A changed `tcc.exe` that starts printing the same etext/end
diagnostic as noise while still exiting 0 overall would still be accepted
as the known XFAIL — the text alone isn't proof the compile actually
failed. Now rejects both signal-terminated exits and exit 0, matching the
same hardening already merged on macos-amd64.

Single-line logic change, no other behavior affected.