### PR TITLE
ci: add linux-amd64 tccbin automation baseline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,25 +5,66 @@ on:
     branches: [thirdparty-linux-amd64]
   pull_request:
     branches: [thirdparty-linux-amd64]
-  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  CONTRACT_REPOSITORY: vlang/v
+  CONTRACT_SHA: 7545e515b434cd399333d43659238427d72e22e7
+  VC_SHA: dfc458a13ba8923ebc249e262c331f8169aa728b
+  PUBLISH: 'false'
+  TCCBIN_PUBLISH: 'false'
 
 jobs:
   build:
+    if: >-
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-linux-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-linux-amd64')
+      )
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       # thirdparty/libgc/include (headers) and thirdparty/tccbin_tests (the
       # shared cross-platform conformance suite - see its README) both live
       # in the main v repo, not here.
       - name: checkout v (for thirdparty/libgc and thirdparty/tccbin_tests)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: vlang/v
-          ref: c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
-          sparse-checkout: |
-            thirdparty/libgc
-            thirdparty/tccbin_tests
-          sparse-checkout-cone-mode: false
+          ref: ${{ env.CONTRACT_SHA }}
           path: work
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: checkout immutable VC bootstrap snapshot
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: vlang/vc
+          ref: ${{ env.VC_SHA }}
+          path: .tccbin-bootstrap-vc
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: bootstrap contract-bound validator
+        shell: bash
+        run: |
+          set -euo pipefail
+          validator_work="$RUNNER_TEMP/tccbin-validator-work"
+          test ! -e "$validator_work"
+          git -C work config --local core.autocrlf false
+          git -C .tccbin-bootstrap-vc config --local core.autocrlf false
+          work/thirdparty/tccbin_automation/bootstrap/bootstrap.sh \
+            "$GITHUB_WORKSPACE/work" "$CONTRACT_REPOSITORY" "$CONTRACT_SHA" \
+            "$GITHUB_WORKSPACE/.tccbin-bootstrap-vc" "$validator_work"
+          {
+            echo "TCCBIN_VALIDATOR_CLI=$validator_work/tccbin-automation"
+            echo "TCCBIN_VALIDATOR_CONTRACT_ROOT=$validator_work/contract-source"
+          } >> "$GITHUB_ENV"
 
       # this branch's already-committed tcc.exe/lib/include, checked out at
       # work/thirdparty/tcc - this exact relative layout matters: the
@@ -36,9 +77,23 @@ jobs:
       # errors that have nothing to do with the actual test being run -
       # reproduced and root-caused locally before writing this workflow.
       - name: checkout this branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ github.sha }}
           path: work/thirdparty/tcc
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: validate baseline manifest and immutable contract binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C work/thirdparty/tcc config --local core.autocrlf false
+          bash work/thirdparty/tcc/automation/probes/baseline-contract.sh \
+            "$TCCBIN_VALIDATOR_CLI" "$TCCBIN_VALIDATOR_CONTRACT_ROOT" \
+            "$GITHUB_WORKSPACE/work/thirdparty/tcc" linux-amd64 \
+            thirdparty-linux-amd64 "$CONTRACT_SHA" "$GITHUB_SHA" \
+            "$GITHUB_WORKSPACE/.tccbin-bootstrap-vc"
 
       - name: run shared conformance tests
         working-directory: work
@@ -57,3 +112,24 @@ jobs:
               -I ./thirdparty/libgc/include \
               ./thirdparty/tcc/lib/libgc.a \
               -ldl -lpthread
+
+  tccbin-branch-gate:
+    name: tccbin-branch-gate
+    if: >-
+      always() &&
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-linux-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-linux-amd64')
+      )
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: require successful baseline validation
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: test "$BUILD_RESULT" = success

--- a/automation/bundle-manifest.json
+++ b/automation/bundle-manifest.json
@@ -1,0 +1,793 @@
+{
+  "schema_version": 1,
+  "contract_version": 1,
+  "contract_repository": "vlang/v",
+  "contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "contract_mode": "production",
+  "v_source_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "target_id": "linux-amd64",
+  "branch": "thirdparty-linux-amd64",
+  "sources": [
+    {
+      "id": "tinycc",
+      "repository": "https://repo.or.cz/tinycc.git",
+      "ref": "mob",
+      "sha": null,
+      "tree": null
+    },
+    {
+      "id": "bdwgc",
+      "repository": "https://github.com/ivmai/bdwgc.git",
+      "ref": "master",
+      "sha": null,
+      "tree": null
+    }
+  ],
+  "recipe": {
+    "path": "build.sh",
+    "version": 1,
+    "sha256": "b9987cb0c9a6901525bae849e44b54d53b9a5d56fb8a98b5c1b38f8e76702ef6"
+  },
+  "toolchain": {
+    "profile_id": null,
+    "profile_sha256": null,
+    "producer_observation": null
+  },
+  "patches": [],
+  "transforms": [],
+  "header_effects": [],
+  "integrations": [],
+  "overlays": [],
+  "inventory": [
+    {
+      "path": "README.md",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d81176c8cd1000148dd10d1c681e963fad6d06cd75a572af8da9c6245d62a205",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2656bb4fa74ca90fe830fdcb58eea0cb1e040cb58c7fb6784b715c8d511c58ec",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "f2c7a944b71db29ee2ea01fa6f7bc730459f4b2cb10ee6b9dafa8f003c6c52fa",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "cbc5e7d0a22103555385be4076566b25e22adbe198089ce7404e50d2c75aa97e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_version.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "1348aea2216945f27f8990d3255861868f9a4eb798fc1ed4ff762588b632a01d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "include/libtcc.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "42e1fb86b44088850e0e17ec0947b483a2edb586b420d18196d7b9b5dce944e4",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/build_libgc.sh",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "0b5ef49e84ca694a9b7e392bc76699a97eb0b18d235dd16e88bb5f3b30273e9c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c06c2131de0eae45642b989b29fd12d11ca0ee8845dbabe86c67eda2e35ee3d6",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "114ce3d00cb9cc50a62e847e824edd52488c5c9f3efab83e25d2b932f4ced3f9",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "79b335ccb51863f3aaa0fe6618405c33e14eb0a35d8d100e267e255739205621",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "bf1ec012e2fb06a5dd5cb23145784ed1461749e54354f9a6edec4984348954e6",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "1005f4b295b6ed9afc6aa02f98e5963f1090d22a31c3ad3b0b72bfd3ed2c42b9",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bcheck.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "8618decf2639b0ca6a97e67b3911562147ffed16e3785300075c0876c5b4bf82",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bt-exe.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "17b16ac2ee0d229b1ff0ccb63fe961b94a3982d40129ef2ed2be5e99536bca97",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bt-log.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "72e1ac001c9b996f03f6de4b8caadf3e0df8933f597f48d6ccb760230103a6c1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/float.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "484ffee95fcdbc00cdc154b9dc2fe03fed65610bf1a73b610871cc39698e6f8e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdalign.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7612d46571099ccaa7616a510f78f180cb1e91671e6e5e9223a2e297b84b789d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdarg.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a38f8d34f5e09658cc3a8892b3a7e80ff566eaeedc194e5a85ece0b675993137",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdatomic.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4fbd9d6ec9add338d41c06f44115121925f087dd91f445b56cca1aacb84360e1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdbool.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "5252824225ddc486b0460677f765e4157af5d3ed7acd65b310a4045eafb56af7",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stddef.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c42eaa62f574527b8d0d64f802b20c27ebeb66feb2c3608e9b9659225ad6ed45",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdnoreturn.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ec64d8fbf7fb2e800df9784b2efca0a99fc25a3eb5e8da56e4df098937f787f2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tccdefs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d1016b6170c45f1b8e7f8d83bf1f00f21e288eb2e446d9f141457f6f821acf7b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tcclib.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2cfbd6b9c5e039721fbfb8e6f95a0a9fc30597bbcb2aefa3dda572c278009429",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tgmath.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e60c66ff9017f13ab18ee38824792ca771b9235bcb4df57688fec582739524a5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/varargs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "07858857f4eed0a61df94beb1a9d678b53fc3d67a0b0e8936155f85ddbcd1dcc",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/libtcc1.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7fac7e6c3717e8e82e7b424a69f5ff47f61eea49ea5448e791ebecc208800215",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/runmain.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c4d28fa3699c6c5f752f25f4a24bb66db73dcaa8a1b8a7496e9b9deecf7d210d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/doc/tcc-doc.html",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ba6f7856d142ee87b00ca198431e7d1c729d18dc115a422dfd2d629b8d11968c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/info/tcc-doc.info",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7f4af35cad222b0690d096bd2d28e464ea4e5d0a07c457bf1f324a70551bda23",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/man/man1/tcc.1",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2eccdb931a965462784dc3468a8759da4618a1a6f05d667e90eb0f33489e60c6",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "outputs": [
+    {
+      "path": "tcc.exe",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "d30e38192a33f88495f69b54bc7b395e6c3c3b087ce4cb0999e6870c12654461",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "native-compiler",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "probes": [
+    {
+      "id": "manifest-contract",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "strict schema, binding, and semantic validation"
+    },
+    {
+      "id": "source-provenance",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "unresolved sources remain explicitly non-publishable"
+    },
+    {
+      "id": "native-build",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "native build succeeds"
+    },
+    {
+      "id": "payload-inventory",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "manifest inventory is expanded before eligibility"
+    },
+    {
+      "id": "patch-probes",
+      "required": true,
+      "expected_lanes": [],
+      "oracle": "empty patchset materializes one expected-zero result"
+    },
+    {
+      "id": "tccbin-conformance",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "shared conformance passes"
+    },
+    {
+      "id": "v-no-fallback-smoke",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "V uses the selected compiler without fallback"
+    },
+    {
+      "id": "artifact-digests",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "declared output digests match"
+    },
+    {
+      "id": "publish-preflight-dry-run",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "publish remains false"
+    }
+  ],
+  "provenance_status": "incomplete",
+  "affected_targets": [
+    "linux-amd64"
+  ]
+}

--- a/automation/probes/baseline-contract.sh
+++ b/automation/probes/baseline-contract.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+export LC_ALL=C
+
+readonly expected_contract_repository='vlang/v'
+
+if [[ $# -ne 8 ]]; then
+	printf '%s\n' 'usage: baseline-contract.sh <validator> <contract-root> <bundle-root> <target-id> <canonical-branch> <contract-sha> <bundle-sha> <vc-root>' >&2
+	exit 2
+fi
+
+validator=$1
+contract_root=$2
+bundle_root=$3
+target_id=$4
+canonical_branch=$5
+expected_contract_sha=$6
+bundle_sha=$7
+vc_root=$8
+manifest="$bundle_root/automation/bundle-manifest.json"
+schema="$contract_root/thirdparty/tccbin_automation/schemas/bundle-manifest.schema.json"
+
+[[ -x "$validator" && -d "$contract_root" && -d "$bundle_root" && -d "$vc_root" ]] || exit 1
+[[ -f "$manifest" && ! -L "$manifest" && -f "$schema" && ! -L "$schema" ]] || exit 1
+[[ "$expected_contract_sha" =~ ^[0-9a-f]{40}$ && "$bundle_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
+
+validator_command() {
+	(cd -P -- "$contract_root" && "$validator" "$@")
+}
+
+case "${PUBLISH:-false}:${TCCBIN_PUBLISH:-false}" in
+	false:false | 0:0 | false:0 | 0:false) ;;
+	*) printf '%s\n' 'baseline contract probe refuses publication' >&2; exit 1 ;;
+esac
+
+binding=$(validator_command contract-binding)
+[[ "$binding" == "repository=$expected_contract_repository sha=$expected_contract_sha" ]] || {
+	printf '%s\n' 'validator contract binding mismatch' >&2
+	exit 1
+}
+
+validator_command contract >/dev/null
+[[ "$(validator_command validate "$schema" "$manifest")" == 'valid' ]]
+canonical=$(validator_command canonicalize "$manifest")
+
+for exact_member in \
+	"\"contract_repository\":\"$expected_contract_repository\"" \
+	"\"contract_sha\":\"$expected_contract_sha\"" \
+	'"contract_mode":"production"' \
+	"\"v_source_sha\":\"$expected_contract_sha\"" \
+	"\"target_id\":\"$target_id\"" \
+	"\"branch\":\"$canonical_branch\"" \
+	'"provenance_status":"incomplete"'; do
+	case "$canonical" in
+		*"$exact_member"*) ;;
+		*) printf '%s\n' 'manifest baseline binding mismatch' >&2; exit 1 ;;
+	esac
+done
+
+fingerprints=$(validator_command fingerprint "$manifest")
+[[ $(printf '%s\n' "$fingerprints" | wc -l | tr -d ' ') == 3 ]]
+for key in manifest_hash input_fingerprint artifact_fingerprint; do
+	value=$(printf '%s\n' "$fingerprints" | sed -n "s/^${key}=//p")
+	[[ "$value" =~ ^[0-9a-f]{64}$ ]]
+done
+
+[[ "$(git -C "$bundle_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$bundle_root" rev-parse HEAD)" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" rev-parse --verify "${bundle_sha}^{commit}")" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" symbolic-ref -q HEAD || true)" == '' ]]
+[[ "$(git -C "$bundle_root" status --porcelain=v1 --untracked-files=all --ignored=matching)" == '' ]]
+
+staging_parent=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+staging_root=$(mktemp -d "$staging_parent/tccbin-payload.XXXXXX")
+cleanup_paths=("$staging_root")
+linked_bundle=false
+for generated_v in v1 v2 v v1.exe v2.exe v.exe; do
+	[[ ! -e "$contract_root/$generated_v" && ! -L "$contract_root/$generated_v" ]]
+done
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+	if [[ "$linked_bundle" == true ]]; then
+		rm -rf -- "$contract_root/thirdparty/tcc"
+	fi
+	rm -f -- "$contract_root/v1" "$contract_root/v2" "$contract_root/v" \
+		"$contract_root/v1.exe" "$contract_root/v2.exe" "$contract_root/v.exe"
+	for cleanup_path in "${cleanup_paths[@]}"; do
+		[[ -n "$cleanup_path" && -d "$cleanup_path" ]] && rm -rf -- "$cleanup_path"
+	done
+	exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+git -C "$bundle_root" archive --format=tar "$bundle_sha" | tar -xf - -C "$staging_root"
+rm -rf -- "$staging_root/.github" "$staging_root/automation"
+case "$target_id" in
+	windows-amd64)
+		rm -f -- \
+			"$staging_root/build.ps1" \
+			"$staging_root/0001-tccpe-strip-quotes-and-default-.dll-extension-in-DEF.patch" \
+			"$staging_root/0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch" \
+			"$staging_root/0003-win32-declare-CreateSymbolicLink.patch" \
+			"$staging_root/0004-win32-declare-WSAConnectBy-family.patch" \
+			"$staging_root/0005-win32-declare-InetNtop-InetPton-family.patch" \
+			"$staging_root/0006-win32-declare-shell-drag-drop-family.patch" \
+			"$staging_root/0007-win32-declare-secure-narrow-stdio.patch" \
+			"$staging_root/0008-win32-fix-exp2-range-reduction.patch" \
+			"$staging_root/0009-win32-declare-CancelIoEx.patch" \
+			"$staging_root/vlang-header-compat.patch" \
+			"$staging_root/v-ae88ee5-tinycc-bdwgc.patch"
+		;;
+	linux-amd64 | macos-amd64 | macos-arm64 | freebsd-amd64 | openbsd-amd64)
+		rm -f -- "$staging_root/build.sh"
+		;;
+	*) printf '%s\n' 'unknown target for payload staging' >&2; exit 1 ;;
+esac
+
+staged_result=$(validator_command staged-preflight \
+	"$manifest" "$staging_root" "$bundle_root" "$bundle_sha" false)
+readonly expected_staged_result='eligible=false reason=staged_provenance_incomplete publish_allowed=false manifest_hash= input_fingerprint= artifact_fingerprint='
+[[ "$staged_result" == "$expected_staged_result" ]] || {
+	printf 'unexpected staged preflight result: %s\n' "$staged_result" >&2
+	exit 1
+}
+
+[[ "$(git -C "$contract_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$vc_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$contract_root" rev-parse HEAD)" == "$expected_contract_sha" ]]
+vc_sha=$(sed -n 's/^commit=//p' "$contract_root/thirdparty/tccbin_automation/bootstrap/vc.lock")
+[[ "$vc_sha" =~ ^[0-9a-f]{40}$ && "$(git -C "$vc_root" rev-parse HEAD)" == "$vc_sha" ]]
+
+contract_tcc="$contract_root/thirdparty/tcc"
+if [[ -e "$contract_tcc" || -L "$contract_tcc" ]]; then
+	[[ "$(cd -P -- "$contract_tcc" && pwd)" == "$(cd -P -- "$bundle_root" && pwd)" ]]
+else
+	ln -s "$bundle_root" "$contract_tcc"
+	linked_bundle=true
+fi
+
+case "$target_id" in
+	windows-amd64)
+		cc_name=${CC:-gcc}
+		exe_suffix=.exe
+		;;
+	*)
+		cc_name=${CC:-cc}
+		exe_suffix=
+		;;
+esac
+cc_path=$(command -v -- "$cc_name")
+[[ "$cc_path" == /* && -x "$cc_path" ]]
+
+if [[ "$target_id" == windows-amd64 ]]; then
+	"$cc_path" -std=c99 -municode -w -o "$contract_root/v1.exe" "$vc_root/v_win.c" \
+		-ladvapi32 -lws2_32 -Wl,-stack=33554432
+	(
+		cd -P -- "$contract_root"
+		./v1.exe -no-parallel -nocache -cc "$cc_path" -o ./v2.exe -gc none cmd/v
+		./v2.exe -no-parallel -nocache -cc "$cc_path" -o ./v.exe -gc none cmd/v
+	)
+else
+	link_flags=(-lm -lpthread)
+	v_link_flags=()
+	case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			link_flags+=(-lexecinfo)
+			v_link_flags=(-ldflags -lexecinfo)
+			;;
+	esac
+	"$cc_path" -std=c99 -w -o "$contract_root/v1" "$vc_root/v.c" "${link_flags[@]}"
+	(
+		cd -P -- "$contract_root"
+		./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none \
+			"${v_link_flags[@]}" cmd/v
+		./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none \
+			"${v_link_flags[@]}" cmd/v
+	)
+fi
+
+smoke_root=$(mktemp -d "$staging_parent/tccbin-v-smoke.XXXXXX")
+cleanup_paths+=("$smoke_root")
+cat > "$smoke_root/main.v" <<'VEOF'
+module main
+
+fn main() {
+	println('tccbin-v-smoke')
+}
+VEOF
+smoke_binary="$smoke_root/tccbin-v-smoke${exe_suffix}"
+if ! showcc_output=$(
+	cd -P -- "$contract_root"
+	"./v${exe_suffix}" -cc tcc -gc none -showcc -no-retry-compilation -no-rsp \
+		-o "$smoke_binary" "$smoke_root/main.v" 2>&1
+); then
+	printf '%s\n' "$showcc_output" >&2
+	exit 1
+fi
+printf '%s\n' "$showcc_output"
+if printf '%s\n' "$showcc_output" | grep -Eiq \
+	'falling back to|retrying with|fallback compiler|backup compiler'; then
+	printf '%s\n' 'V attempted a compiler fallback' >&2
+	exit 1
+fi
+normalized_showcc=$(printf '%s\n' "$showcc_output" | tr '\\' '/')
+case "$normalized_showcc" in
+	*'/thirdparty/tcc/tcc.exe'*) ;;
+	*) printf '%s\n' 'V did not report the bundled tcc.exe command' >&2; exit 1 ;;
+esac
+[[ -f "$smoke_binary" ]]
+[[ "$($smoke_binary)" == 'tccbin-v-smoke' ]]
+
+printf 'tccbin baseline contract target=%s staged=incomplete smoke=v-tcc publish=false: PASS\n' "$target_id"


### PR DESCRIPTION
## Summary

This PR adds the Phase A read-only automation baseline for the Linux AMD64 tccbin bundle and binds it to the merged `vlang/v` automation contract.

It adds an immutable bundle manifest, contract and provenance validation, a no-fallback V smoke test, and the existing native conformance checks behind a single branch gate.

## Why

The goal is to make future tccbin updates reproducible and auditable, while rejecting stale, incomplete, or unverified candidates before they can reach a publication path.

## Safety

This PR does not enable publication. Provenance remains incomplete, `PUBLISH` and `TCCBIN_PUBLISH` stay disabled, and the workflow has no secrets, artifact uploads, or Git push capability.