### PR TITLE
ci: add freebsd-amd64 tccbin automation baseline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,103 +5,118 @@ on:
     branches: [thirdparty-freebsd-amd64]
   pull_request:
     branches: [thirdparty-freebsd-amd64]
-  workflow_dispatch: {}
+
+permissions:
+  contents: read
 
 jobs:
   build:
+    name: freebsd-amd64 read-only validation
+    if: >-
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-freebsd-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-freebsd-amd64')
+      )
     runs-on: ubuntu-latest
-    # `github.sha` and `github.event.repository.clone_url` are used
-    # uniformly across all 3 trigger event types, and correctly cover
-    # each:
-    # - pull_request: `github.sha` is GitHub's own synthesized MERGE
-    #   commit (what the target branch would actually look like if
-    #   this PR were merged right now), not the PR branch's own head -
-    #   testing only the head tree in isolation could pass a PR whose
-    #   OWN commit works fine, while the actual merge result (combined
-    #   with whatever the target branch has since gained) is broken
-    #   (Codex pullrequestreview-4781865117 on vlang/tccbin#75). That
-    #   merge commit exists ONLY as an object in the base repo
-    #   (vlang/tccbin, exposed via `refs/pull/<n>/merge`) - never in a
-    #   contributor's fork - so this must clone from
-    #   `github.event.repository.clone_url` (the base repo), not the
-    #   fork's URL, regardless of where the PR originated.
-    # - push/workflow_dispatch: `github.sha`/`github.event.repository`
-    #   are simply the pushed/dispatched commit and the repo it lives
-    #   in - already exactly what should be tested.
-    # In every case, `github.sha` is fixed for this run's entire
-    # lifetime once the triggering event fires (a later push creates a
-    # brand new run with its own new `github.sha`, it doesn't mutate
-    # this one) - so this is exactly as race-safe against a
-    # mid-queue push as the earlier head.sha-based approach was (Codex
-    # pullrequestreview-4780048339 on vlang/tccbin#75), while also
-    # testing the actual merge result instead of the head tree alone.
-    # Set at job level (matching update_tccbin.yml's own working BSD
-    # job env, which only ever references github.*/secrets.*, never
-    # steps.* - step-level env on the "Start VM" step was tried first
-    # and empirically did NOT get forwarded into the VM by
-    # environment_variables, unlike this job-level placement).
+    timeout-minutes: 60
     env:
-      TCCBIN_CLONE_URL: ${{ github.event.repository.clone_url }}
+      TARGET_ID: freebsd-amd64
+      CANONICAL_BRANCH: thirdparty-freebsd-amd64
+      TCCBIN_CLONE_URL: https://github.com/vlang/tccbin
       TCCBIN_CLONE_SHA: ${{ github.sha }}
+      CONTRACT_REPOSITORY: vlang/v
+      CONTRACT_CLONE_URL: https://github.com/vlang/v
+      CONTRACT_SHA: 7545e515b434cd399333d43659238427d72e22e7
+      VC_CLONE_URL: https://github.com/vlang/vc
+      VC_SHA: dfc458a13ba8923ebc249e262c331f8169aa728b
+      PUBLISH: 'false'
+      TCCBIN_PUBLISH: 'false'
     steps:
-      # cross-platform-actions/action boots a real FreeBSD VM inside this
-      # Linux runner - the same action vlang/v's own update_tccbin.yml
-      # uses to rebuild this branch's binaries. Cloning both repos
-      # directly inside the VM (rather than actions/checkout on the
-      # runner + sync_files) mirrors that proven-working pattern instead
-      # of relying on an unverified file-permission-preserving sync.
-      # Pinned to the v1.3.0 tag's commit (resolved via the GitHub API)
-      # rather than the mutable tag itself, so a retag upstream can't
-      # silently swap in different third-party code here without a
-      # review-visible diff (Codex pullrequestreview-4780048339 on
-      # vlang/tccbin#75).
       - name: Start freebsd-amd64 VM
-        uses: cross-platform-actions/action@4347c661239bf5dcd0cd77708061488d907343d6 # v1.3.0
+        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4
         with:
           operating_system: freebsd
           version: '15.1'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_SHA
+          environment_variables: >-
+            TARGET_ID CANONICAL_BRANCH
+            TCCBIN_CLONE_URL TCCBIN_CLONE_SHA
+            CONTRACT_REPOSITORY CONTRACT_CLONE_URL CONTRACT_SHA
+            VC_CLONE_URL VC_SHA PUBLISH TCCBIN_PUBLISH
 
-      - name: fetch shared conformance suite and this branch's binaries
-        shell: cpa.sh {0}
+      - name: Bootstrap immutable contract and run baseline probe
+        shell: cpa.sh {0} --sync-files none
         run: |
           set -eu
+          umask 077
           sudo pkg install -y bash git
 
-          # Fetch the exact commit that triggered this run, not a branch
-          # name - `git clone --branch <name>` would resolve whatever
-          # that name points to *at clone time*, which can race a push
-          # that lands after this run started (Codex pullrequestreview-
-          # 4780048339 on vlang/tccbin#75).
-          mkdir -p thirdparty/tcc && cd thirdparty/tcc
-          git init -q
-          git remote add origin "$TCCBIN_CLONE_URL"
-          git fetch --depth=1 origin "$TCCBIN_CLONE_SHA"
-          git checkout -q FETCH_HEAD
-          cd ../..
+          test "$PUBLISH" = false
+          test "$TCCBIN_PUBLISH" = false
+          test "$CONTRACT_REPOSITORY" = vlang/v
+          test "$CONTRACT_CLONE_URL" = "https://github.com/$CONTRACT_REPOSITORY"
+          test "$VC_CLONE_URL" = https://github.com/vlang/vc
 
-          # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
-          # (the shared cross-platform conformance suite) both live in
-          # the main v repo, not here. A plain `git clone --depth=1`
-          # only ever contains the CURRENT tip commit's objects - once
-          # vlang/v advances past this pinned SHA, that historical commit
-          # object won't exist in a fresh shallow clone and this checkout
-          # would fail (Codex P1, pullrequestreview-4780048339 on
-          # vlang/tccbin#75, line 60). Fetch that exact SHA directly
-          # instead of cloning HEAD and hoping it's still there.
-          mkdir -p vsrc && cd vsrc
-          git init -q
-          git remote add origin https://github.com/vlang/v.git
-          git sparse-checkout init --no-cone
-          git sparse-checkout set thirdparty/libgc thirdparty/tccbin_tests
-          git fetch --filter=blob:none --depth=1 origin c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
-          git checkout -q FETCH_HEAD
-          cd ..
+          checkout_exact() {
+            checkout_repository=$1
+            checkout_sha=$2
+            checkout_destination=$3
+            checkout_history=$4
 
-          chmod +x thirdparty/tcc/tcc.exe
+            test "${#checkout_sha}" -eq 40
+            case "$checkout_sha" in
+              *[!0-9a-f]*) exit 1 ;;
+            esac
+            test ! -e "$checkout_destination"
+            mkdir -p "$checkout_destination"
+            git -C "$checkout_destination" init -q
+            git -C "$checkout_destination" config --local core.autocrlf false
+            git -C "$checkout_destination" remote add origin "$checkout_repository"
+            if test "$checkout_history" = shallow; then
+              GIT_TERMINAL_PROMPT=0 git -C "$checkout_destination" \
+                fetch --no-tags --depth=1 origin "$checkout_sha"
+            else
+              GIT_TERMINAL_PROMPT=0 git -C "$checkout_destination" \
+                fetch --no-tags origin "$checkout_sha"
+            fi
+            git -C "$checkout_destination" checkout -q --detach FETCH_HEAD
+            test "$(git -C "$checkout_destination" rev-parse HEAD)" = "$checkout_sha"
+            if test "$checkout_history" = full; then
+              test "$(git -C "$checkout_destination" \
+                rev-parse --is-shallow-repository)" = false
+            fi
+          }
+
+          mkdir -p "$PWD/thirdparty"
+          checkout_exact "$TCCBIN_CLONE_URL" "$TCCBIN_CLONE_SHA" \
+            "$PWD/thirdparty/tcc" shallow
+          checkout_exact "$CONTRACT_CLONE_URL" "$CONTRACT_SHA" \
+            "$PWD/vsrc" full
+
+          contract_work="$(mktemp -d "${TMPDIR:-/tmp}/tccbin-contract.XXXXXX")"
+          vc_root="$contract_work/vc"
+          validator_work="$contract_work/validator"
+          checkout_exact "$VC_CLONE_URL" "$VC_SHA" "$vc_root" full
+
+          bash "$PWD/vsrc/thirdparty/tccbin_automation/bootstrap/bootstrap.sh" \
+            "$PWD/vsrc" "$CONTRACT_REPOSITORY" "$CONTRACT_SHA" \
+            "$vc_root" "$validator_work"
+
+          test -x "$validator_work/tccbin-automation"
+          test -d "$validator_work/contract-source"
+          chmod +x "$PWD/thirdparty/tcc/tcc.exe"
+          PUBLISH=false TCCBIN_PUBLISH=false \
+            bash "$PWD/thirdparty/tcc/automation/probes/baseline-contract.sh" \
+              "$validator_work/tccbin-automation" \
+              "$validator_work/contract-source" \
+              "$PWD/thirdparty/tcc" \
+              "$TARGET_ID" "$CANONICAL_BRANCH" "$CONTRACT_SHA" \
+              "$TCCBIN_CLONE_SHA" "$vc_root"
 
       # HISTORY: tcc on FreeBSD used to be unable to link the bundled
       # libgc.a at all - its linker only ever defined the glibc-style
@@ -124,7 +139,7 @@ jobs:
       # broken toolchain even if the GC lane were to fail for its own
       # unrelated reasons.
       - name: run shared conformance tests (crash only, no GC - blocking)
-        shell: cpa.sh {0}
+        shell: cpa.sh {0} --sync-files none
         run: |
           set -eu
           thirdparty/tcc/tcc.exe vsrc/thirdparty/tccbin_tests/shared/crash.c \
@@ -152,8 +167,7 @@ jobs:
           # broken libtcc1.a/crt or startup path made EVERY program
           # segfault immediately (before ever reaching the intentional
           # null-pointer dereference), this check would still see exit
-          # 139 and wrongly call it "expected" (Codex pullrequestreview-
-          # 4781468264 on vlang/tccbin#75). Keep this positive check
+          # 139 and wrongly call it "expected". Keep this positive check
           # independent of the GC lane below rather than relying on it:
           # this lane's whole purpose is to stay meaningful on its own,
           # covering the plain no-GC toolchain path that a GC-linked test
@@ -197,7 +211,7 @@ jobs:
       # contains 384614a) reports "3 passed, 0 failed". tcc.exe was the
       # only variable between the two.
       - name: run shared conformance tests (libgc.a - blocking)
-        shell: cpa.sh {0}
+        shell: cpa.sh {0} --sync-files none
         run: |
           set -eu
           bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" freebsd -- \
@@ -221,7 +235,7 @@ jobs:
       # reported all three "absent" for a binary that had just linked and
       # run correctly.
       - name: verify the linker provides etext/edata/end (blocking)
-        shell: cpa.sh {0}
+        shell: cpa.sh {0} --sync-files none
         if: ${{ !cancelled() }}
         run: |
           set -eu
@@ -268,3 +282,26 @@ jobs:
           thirdparty/tcc/tcc.exe /tmp/boundary_probe.c -o /tmp/boundary_probe
           /tmp/boundary_probe
           echo "confirmed: the linker provides etext/edata/end, and the advertised range is ordered sanely"
+
+  tccbin-branch-gate:
+    name: tccbin-branch-gate
+    if: >-
+      always() &&
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-freebsd-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-freebsd-amd64')
+      )
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: require successful FreeBSD validation
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          test "$BUILD_RESULT" = success

--- a/automation/bundle-manifest.json
+++ b/automation/bundle-manifest.json
@@ -1,0 +1,751 @@
+{
+  "schema_version": 1,
+  "contract_version": 1,
+  "contract_repository": "vlang/v",
+  "contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "contract_mode": "production",
+  "v_source_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "target_id": "freebsd-amd64",
+  "branch": "thirdparty-freebsd-amd64",
+  "sources": [
+    {
+      "id": "tinycc",
+      "repository": "https://repo.or.cz/tinycc.git",
+      "ref": "mob",
+      "sha": null,
+      "tree": null
+    },
+    {
+      "id": "bdwgc",
+      "repository": "https://github.com/ivmai/bdwgc.git",
+      "ref": "master",
+      "sha": null,
+      "tree": null
+    }
+  ],
+  "recipe": {
+    "path": "build.sh",
+    "version": 1,
+    "sha256": "254cb4df030e7bfe04d7a1d89fb9caeb596ae84eff4bfe24b9d685406ad2df1c"
+  },
+  "toolchain": {
+    "profile_id": null,
+    "profile_sha256": null,
+    "producer_observation": null
+  },
+  "patches": [],
+  "transforms": [],
+  "header_effects": [],
+  "integrations": [],
+  "overlays": [],
+  "inventory": [
+    {
+      "path": "README.md",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "1922c95415bc6ebfb681a0190f578d96cfc31f5b54bf78ca21563b858e8f8965",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "be9c1e872e52fdaec3abb1256b85652220111844aeb6a21bf543d26d05f82f2e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "032dcfc77a7d7521a104b216635b4a5644c19bbb657bc69e0f8ae0203f3ae327",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "bc94d74ba8f626d626f7ab2b60199e374c8ae8ca6f572202f109ca7d6235fb16",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_version.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4b7671bf2cbd0d1122f27cd38cf6794a60485d49a46e5e7635e135bc008bf08b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "include/libtcc.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "42e1fb86b44088850e0e17ec0947b483a2edb586b420d18196d7b9b5dce944e4",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/build_empty",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "3ffe249d4a390b3dc8b11ca699fa7fe6a98ada08a0c39948731ed012946e860a",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ae918b955ddb691acc5587f3750b6e71e6c5af7e56d67194e71de0ea1c91fe05",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e7e398db7af8c6bceec0f3876976b706883dfb1ca434aa973ce76a52f8fbf659",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2f5a52d7dd827d633ccb347032bffa5048544434d29ab0cb03a136f6e074f1f8",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a1f81e084fb922645bd1671cd22836e71f8b8aaa8e6aeb36043e95c1364e2a6b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bcheck.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "be56ae5c497dfd7195b87b108b6bacd61f0038d5a4ed55eb1728877f6529ff1a",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bt-exe.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "15ffd6e8dbb16cddb9d521cb6c80a27056f69a458ebbdd53c01f3050f22e0a49",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bt-log.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "3da255796d4f22f451b9f1f2a15fe3be02c9f33de5c15f1b337ab94a32e1b065",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/float.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "484ffee95fcdbc00cdc154b9dc2fe03fed65610bf1a73b610871cc39698e6f8e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdalign.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7612d46571099ccaa7616a510f78f180cb1e91671e6e5e9223a2e297b84b789d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdarg.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a38f8d34f5e09658cc3a8892b3a7e80ff566eaeedc194e5a85ece0b675993137",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdatomic.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4fbd9d6ec9add338d41c06f44115121925f087dd91f445b56cca1aacb84360e1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdbool.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "5252824225ddc486b0460677f765e4157af5d3ed7acd65b310a4045eafb56af7",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stddef.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c42eaa62f574527b8d0d64f802b20c27ebeb66feb2c3608e9b9659225ad6ed45",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdnoreturn.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ec64d8fbf7fb2e800df9784b2efca0a99fc25a3eb5e8da56e4df098937f787f2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tccdefs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d1016b6170c45f1b8e7f8d83bf1f00f21e288eb2e446d9f141457f6f821acf7b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tcclib.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2cfbd6b9c5e039721fbfb8e6f95a0a9fc30597bbcb2aefa3dda572c278009429",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tgmath.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e60c66ff9017f13ab18ee38824792ca771b9235bcb4df57688fec582739524a5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/varargs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "07858857f4eed0a61df94beb1a9d678b53fc3d67a0b0e8936155f85ddbcd1dcc",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/libtcc1.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "13b226efb47f2817a04706a91e8169f5f4cf4cfd9a0e72027d1b89040e2b335a",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/runmain.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "3e1579294d84fbf9d7698e849f9a5f74aedfe65080afd39a938a19212b3bac0c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/man/man1/tcc.1",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "89a72bd3a03f021ea5a6d3e1ec93998606c8e4d5a2fdbb9a4c3f3b098073b4f0",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "outputs": [
+    {
+      "path": "tcc.exe",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "e3dbad5a2246798101e20eedf03fde23db51253b34f67a797ba129118f436478",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "native-compiler",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "probes": [
+    {
+      "id": "manifest-contract",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "strict schema, binding, and semantic validation"
+    },
+    {
+      "id": "source-provenance",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "unresolved sources remain explicitly non-publishable"
+    },
+    {
+      "id": "native-build",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "native build succeeds"
+    },
+    {
+      "id": "payload-inventory",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "manifest inventory is expanded before eligibility"
+    },
+    {
+      "id": "patch-probes",
+      "required": true,
+      "expected_lanes": [],
+      "oracle": "empty patchset materializes one expected-zero result"
+    },
+    {
+      "id": "tccbin-conformance",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "shared conformance passes"
+    },
+    {
+      "id": "v-no-fallback-smoke",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "V uses the selected compiler without fallback"
+    },
+    {
+      "id": "artifact-digests",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "declared output digests match"
+    },
+    {
+      "id": "publish-preflight-dry-run",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "publish remains false"
+    }
+  ],
+  "provenance_status": "incomplete",
+  "affected_targets": [
+    "freebsd-amd64"
+  ]
+}

--- a/automation/probes/baseline-contract.sh
+++ b/automation/probes/baseline-contract.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+export LC_ALL=C
+
+readonly expected_contract_repository='vlang/v'
+
+if [[ $# -ne 8 ]]; then
+	printf '%s\n' 'usage: baseline-contract.sh <validator> <contract-root> <bundle-root> <target-id> <canonical-branch> <contract-sha> <bundle-sha> <vc-root>' >&2
+	exit 2
+fi
+
+validator=$1
+contract_root=$2
+bundle_root=$3
+target_id=$4
+canonical_branch=$5
+expected_contract_sha=$6
+bundle_sha=$7
+vc_root=$8
+manifest="$bundle_root/automation/bundle-manifest.json"
+schema="$contract_root/thirdparty/tccbin_automation/schemas/bundle-manifest.schema.json"
+
+[[ -x "$validator" && -d "$contract_root" && -d "$bundle_root" && -d "$vc_root" ]] || exit 1
+[[ -f "$manifest" && ! -L "$manifest" && -f "$schema" && ! -L "$schema" ]] || exit 1
+[[ "$expected_contract_sha" =~ ^[0-9a-f]{40}$ && "$bundle_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
+
+validator_command() {
+	(cd -P -- "$contract_root" && "$validator" "$@")
+}
+
+case "${PUBLISH:-false}:${TCCBIN_PUBLISH:-false}" in
+	false:false | 0:0 | false:0 | 0:false) ;;
+	*) printf '%s\n' 'baseline contract probe refuses publication' >&2; exit 1 ;;
+esac
+
+binding=$(validator_command contract-binding)
+[[ "$binding" == "repository=$expected_contract_repository sha=$expected_contract_sha" ]] || {
+	printf '%s\n' 'validator contract binding mismatch' >&2
+	exit 1
+}
+
+validator_command contract >/dev/null
+[[ "$(validator_command validate "$schema" "$manifest")" == 'valid' ]]
+canonical=$(validator_command canonicalize "$manifest")
+
+for exact_member in \
+	"\"contract_repository\":\"$expected_contract_repository\"" \
+	"\"contract_sha\":\"$expected_contract_sha\"" \
+	'"contract_mode":"production"' \
+	"\"v_source_sha\":\"$expected_contract_sha\"" \
+	"\"target_id\":\"$target_id\"" \
+	"\"branch\":\"$canonical_branch\"" \
+	'"provenance_status":"incomplete"'; do
+	case "$canonical" in
+		*"$exact_member"*) ;;
+		*) printf '%s\n' 'manifest baseline binding mismatch' >&2; exit 1 ;;
+	esac
+done
+
+fingerprints=$(validator_command fingerprint "$manifest")
+[[ $(printf '%s\n' "$fingerprints" | wc -l | tr -d ' ') == 3 ]]
+for key in manifest_hash input_fingerprint artifact_fingerprint; do
+	value=$(printf '%s\n' "$fingerprints" | sed -n "s/^${key}=//p")
+	[[ "$value" =~ ^[0-9a-f]{64}$ ]]
+done
+
+[[ "$(git -C "$bundle_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$bundle_root" rev-parse HEAD)" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" rev-parse --verify "${bundle_sha}^{commit}")" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" symbolic-ref -q HEAD || true)" == '' ]]
+[[ "$(git -C "$bundle_root" status --porcelain=v1 --untracked-files=all --ignored=matching)" == '' ]]
+
+staging_parent=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+staging_root=$(mktemp -d "$staging_parent/tccbin-payload.XXXXXX")
+cleanup_paths=("$staging_root")
+linked_bundle=false
+for generated_v in v1 v2 v v1.exe v2.exe v.exe; do
+	[[ ! -e "$contract_root/$generated_v" && ! -L "$contract_root/$generated_v" ]]
+done
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+	if [[ "$linked_bundle" == true ]]; then
+		rm -rf -- "$contract_root/thirdparty/tcc"
+	fi
+	rm -f -- "$contract_root/v1" "$contract_root/v2" "$contract_root/v" \
+		"$contract_root/v1.exe" "$contract_root/v2.exe" "$contract_root/v.exe"
+	for cleanup_path in "${cleanup_paths[@]}"; do
+		[[ -n "$cleanup_path" && -d "$cleanup_path" ]] && rm -rf -- "$cleanup_path"
+	done
+	exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+git -C "$bundle_root" archive --format=tar "$bundle_sha" | tar -xf - -C "$staging_root"
+rm -rf -- "$staging_root/.github" "$staging_root/automation"
+case "$target_id" in
+	windows-amd64)
+		rm -f -- \
+			"$staging_root/build.ps1" \
+			"$staging_root/0001-tccpe-strip-quotes-and-default-.dll-extension-in-DEF.patch" \
+			"$staging_root/0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch" \
+			"$staging_root/0003-win32-declare-CreateSymbolicLink.patch" \
+			"$staging_root/0004-win32-declare-WSAConnectBy-family.patch" \
+			"$staging_root/0005-win32-declare-InetNtop-InetPton-family.patch" \
+			"$staging_root/0006-win32-declare-shell-drag-drop-family.patch" \
+			"$staging_root/0007-win32-declare-secure-narrow-stdio.patch" \
+			"$staging_root/0008-win32-fix-exp2-range-reduction.patch" \
+			"$staging_root/0009-win32-declare-CancelIoEx.patch" \
+			"$staging_root/vlang-header-compat.patch" \
+			"$staging_root/v-ae88ee5-tinycc-bdwgc.patch"
+		;;
+	linux-amd64 | macos-amd64 | macos-arm64 | freebsd-amd64 | openbsd-amd64)
+		rm -f -- "$staging_root/build.sh"
+		;;
+	*) printf '%s\n' 'unknown target for payload staging' >&2; exit 1 ;;
+esac
+
+staged_result=$(validator_command staged-preflight \
+	"$manifest" "$staging_root" "$bundle_root" "$bundle_sha" false)
+readonly expected_staged_result='eligible=false reason=staged_provenance_incomplete publish_allowed=false manifest_hash= input_fingerprint= artifact_fingerprint='
+[[ "$staged_result" == "$expected_staged_result" ]] || {
+	printf 'unexpected staged preflight result: %s\n' "$staged_result" >&2
+	exit 1
+}
+
+[[ "$(git -C "$contract_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$vc_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$contract_root" rev-parse HEAD)" == "$expected_contract_sha" ]]
+vc_sha=$(sed -n 's/^commit=//p' "$contract_root/thirdparty/tccbin_automation/bootstrap/vc.lock")
+[[ "$vc_sha" =~ ^[0-9a-f]{40}$ && "$(git -C "$vc_root" rev-parse HEAD)" == "$vc_sha" ]]
+
+contract_tcc="$contract_root/thirdparty/tcc"
+if [[ -e "$contract_tcc" || -L "$contract_tcc" ]]; then
+	[[ "$(cd -P -- "$contract_tcc" && pwd)" == "$(cd -P -- "$bundle_root" && pwd)" ]]
+else
+	ln -s "$bundle_root" "$contract_tcc"
+	linked_bundle=true
+fi
+
+case "$target_id" in
+	windows-amd64)
+		cc_name=${CC:-gcc}
+		exe_suffix=.exe
+		;;
+	*)
+		cc_name=${CC:-cc}
+		exe_suffix=
+		;;
+esac
+cc_path=$(command -v -- "$cc_name")
+[[ "$cc_path" == /* && -x "$cc_path" ]]
+
+if [[ "$target_id" == windows-amd64 ]]; then
+	"$cc_path" -std=c99 -municode -w -o "$contract_root/v1.exe" "$vc_root/v_win.c" \
+		-ladvapi32 -lws2_32 -Wl,-stack=33554432
+	(
+		cd -P -- "$contract_root"
+		./v1.exe -no-parallel -nocache -cc "$cc_path" -o ./v2.exe -gc none cmd/v
+		./v2.exe -no-parallel -nocache -cc "$cc_path" -o ./v.exe -gc none cmd/v
+	)
+else
+	link_flags=(-lm -lpthread)
+	v_link_flags=()
+	case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			link_flags+=(-lexecinfo)
+			v_link_flags=(-ldflags -lexecinfo)
+			;;
+	esac
+	"$cc_path" -std=c99 -w -o "$contract_root/v1" "$vc_root/v.c" "${link_flags[@]}"
+	(
+		cd -P -- "$contract_root"
+		./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none \
+			"${v_link_flags[@]}" cmd/v
+		./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none \
+			"${v_link_flags[@]}" cmd/v
+	)
+fi
+
+smoke_root=$(mktemp -d "$staging_parent/tccbin-v-smoke.XXXXXX")
+cleanup_paths+=("$smoke_root")
+cat > "$smoke_root/main.v" <<'VEOF'
+module main
+
+fn main() {
+	println('tccbin-v-smoke')
+}
+VEOF
+smoke_binary="$smoke_root/tccbin-v-smoke${exe_suffix}"
+if ! showcc_output=$(
+	cd -P -- "$contract_root"
+	"./v${exe_suffix}" -cc tcc -gc none -showcc -no-retry-compilation -no-rsp \
+		-o "$smoke_binary" "$smoke_root/main.v" 2>&1
+); then
+	printf '%s\n' "$showcc_output" >&2
+	exit 1
+fi
+printf '%s\n' "$showcc_output"
+if printf '%s\n' "$showcc_output" | grep -Eiq \
+	'falling back to|retrying with|fallback compiler|backup compiler'; then
+	printf '%s\n' 'V attempted a compiler fallback' >&2
+	exit 1
+fi
+normalized_showcc=$(printf '%s\n' "$showcc_output" | tr '\\' '/')
+case "$normalized_showcc" in
+	*'/thirdparty/tcc/tcc.exe'*) ;;
+	*) printf '%s\n' 'V did not report the bundled tcc.exe command' >&2; exit 1 ;;
+esac
+[[ -f "$smoke_binary" ]]
+[[ "$($smoke_binary)" == 'tccbin-v-smoke' ]]
+
+printf 'tccbin baseline contract target=%s staged=incomplete smoke=v-tcc publish=false: PASS\n' "$target_id"


### PR DESCRIPTION
## Summary

This PR adds the Phase A read-only automation baseline for the FreeBSD AMD64 tccbin bundle and binds it to the merged `vlang/v` automation contract.

It adds an immutable bundle manifest, contract and provenance validation, a no-fallback V smoke test, and the existing native and linker conformance checks behind a single branch gate.

## Why

The goal is to make future tccbin updates reproducible and auditable, while rejecting stale, incomplete, or unverified candidates before they can reach a publication path.

## Safety

This PR does not enable publication. Provenance remains incomplete, `PUBLISH` and `TCCBIN_PUBLISH` stay disabled, and the workflow has no secrets, artifact uploads, or Git push capability.