### PR TITLE
ci: add macos-arm64 tccbin automation baseline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,7 +5,16 @@ on:
     branches: [thirdparty-macos-arm64]
   pull_request:
     branches: [thirdparty-macos-arm64]
-  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  CONTRACT_REPOSITORY: vlang/v
+  CONTRACT_SHA: 7545e515b434cd399333d43659238427d72e22e7
+  VC_SHA: dfc458a13ba8923ebc249e262c331f8169aa728b
+  PUBLISH: 'false'
+  TCCBIN_PUBLISH: 'false'
 
 concurrency:
   group: build-and-test-macos-arm64-${{ github.ref }}
@@ -13,6 +22,14 @@ concurrency:
 
 jobs:
   build:
+    if: >-
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-macos-arm64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-macos-arm64')
+      )
     runs-on: macos-15
     timeout-minutes: 30
     steps:
@@ -26,23 +43,59 @@ jobs:
       # this branch reuses its own prebuilt libgc.a/libgc.dylib rather
       # than compiling thirdparty/libgc/gc.c from source.
       - name: checkout v (for thirdparty/libgc and thirdparty/tccbin_tests)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: vlang/v
-          ref: c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
-          sparse-checkout: |
-            thirdparty/libgc/include
-            thirdparty/tccbin_tests
-            vlib/v/compiler_errors_test.v
-          sparse-checkout-cone-mode: false
+          ref: ${{ env.CONTRACT_SHA }}
           path: work
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: checkout immutable VC bootstrap snapshot
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: vlang/vc
+          ref: ${{ env.VC_SHA }}
+          path: .tccbin-bootstrap-vc
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: bootstrap contract-bound validator
+        shell: bash
+        run: |
+          set -euo pipefail
+          validator_work="$RUNNER_TEMP/tccbin-validator-work"
+          test ! -e "$validator_work"
+          git -C work config --local core.autocrlf false
+          git -C .tccbin-bootstrap-vc config --local core.autocrlf false
+          work/thirdparty/tccbin_automation/bootstrap/bootstrap.sh \
+            "$GITHUB_WORKSPACE/work" "$CONTRACT_REPOSITORY" "$CONTRACT_SHA" \
+            "$GITHUB_WORKSPACE/.tccbin-bootstrap-vc" "$validator_work"
+          {
+            echo "TCCBIN_VALIDATOR_CLI=$validator_work/tccbin-automation"
+            echo "TCCBIN_VALIDATOR_CONTRACT_ROOT=$validator_work/contract-source"
+          } >> "$GITHUB_ENV"
 
       # this branch, checked out where build.sh expects to find itself
       # (work/thirdparty/tcc), matching a normal local checkout layout.
       - name: checkout this branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ github.sha }}
           path: work/thirdparty/tcc
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: validate baseline manifest and immutable contract binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C work/thirdparty/tcc config --local core.autocrlf false
+          bash work/thirdparty/tcc/automation/probes/baseline-contract.sh \
+            "$TCCBIN_VALIDATOR_CLI" "$TCCBIN_VALIDATOR_CONTRACT_ROOT" \
+            "$GITHUB_WORKSPACE/work/thirdparty/tcc" macos-arm64 \
+            thirdparty-macos-arm64 "$CONTRACT_SHA" "$GITHUB_SHA" \
+            "$GITHUB_WORKSPACE/.tccbin-bootstrap-vc"
 
       # This branch DISTRIBUTES the checked-in tcc.exe/libgc.a/libgc.dylib
       # directly - that's what V's own builder and anyone else using this
@@ -195,11 +248,64 @@ jobs:
           if [ "$code" -eq 0 ]; then
             echo "::error::Static libgc.a linking now succeeds on macOS arm64 - this lane's special-casing should be removed and folded back into a single blocking lane, this workaround is no longer needed."
             exit 1
+          elif [ "$code" -ne 1 ]; then
+            echo "::error::Static libgc.a XFAIL returned exit $code; expected TCC compile-error exit 1 exactly."
+            exit 1
           fi
 
+          set +e
+          direct_err_gc_alloc=$(thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/gc_alloc.c \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -DGC_THREADS=1 \
+              -DMPROTECT_VDB=1 \
+              -I thirdparty/libgc/include \
+              "$PWD/thirdparty/tcc/lib/libgc.a" \
+              -ldl -lpthread \
+              -o /tmp/gc_alloc_arm64_xfail_probe 2>&1)
+          direct_code_gc_alloc=$?
+          direct_err_hello=$(thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/hello.c \
+              -DGC_BUILTIN_ATOMIC=1 \
+              -DGC_THREADS=1 \
+              -DMPROTECT_VDB=1 \
+              -I thirdparty/libgc/include \
+              "$PWD/thirdparty/tcc/lib/libgc.a" \
+              -ldl -lpthread \
+              -o /tmp/hello_arm64_xfail_probe 2>&1)
+          direct_code_hello=$?
+          set -e
+
+          is_known_gc_init() {
+            # TCC's compile-error exit is exactly 1. Every nonempty stderr
+            # line must be one complete unresolved GC_* diagnostic; require
+            # GC_init specifically so an unrelated missing symbol cannot
+            # masquerade as the known archive-parsing limitation.
+            if [ "$2" -ne 1 ]; then
+              return 1
+            fi
+            stderr_lines=$(printf '%s\n' "$1" | sed '/^$/d')
+            [ -n "$stderr_lines" ] || return 1
+            unexpected=$(printf '%s\n' "$stderr_lines" | grep -Ev "^tcc: error: unresolved reference to '_?GC_[A-Za-z0-9_]+'$" || true)
+            [ -z "$unexpected" ] || return 1
+            printf '%s\n' "$stderr_lines" | grep -E "^tcc: error: unresolved reference to '_?GC_init'$" >/dev/null
+          }
+
+          pass_count=$(printf '%s\n' "$output" | grep -Ec '^PASS ' || true)
+          fail_count=$(printf '%s\n' "$output" | grep -Ec '^FAIL ' || true)
+          final_summary=$(printf '%s\n' "$output" | sed '/^$/d' | tail -n 1)
           case "$output" in
-            *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
-              echo "known XFAIL: static libgc.a still can't link gc_alloc/hello, as expected - not blocking CI"
+            *"PASS crash"*"FAIL gc_alloc (compile error:"*"FAIL hello (compile error:"*)
+              if [ "$pass_count" -ne 1 ] || [ "$fail_count" -ne 2 ] || [ "$final_summary" != '1 passed, 2 failed' ]; then
+                echo "::error::Static libgc.a summary counts/final line differ from the exact known XFAIL (PASS=1, FAIL=2, final='1 passed, 2 failed')."
+                exit 1
+              fi
+              if is_known_gc_init "$direct_err_gc_alloc" "$direct_code_gc_alloc" && is_known_gc_init "$direct_err_hello" "$direct_code_hello"; then
+                echo "known XFAIL: static libgc.a still can't link gc_alloc/hello (unresolved GC_init, the known tcc archive-parsing bug), as expected - not blocking CI"
+              else
+                echo "::error::libgc.a lane failed with the known summary shape, but at least one of gc_alloc.c/hello.c's direct compile errors does NOT mention an unresolved GC_init reference (or exited abnormally) - this looks like a different, unexpected regression:"
+                echo "gc_alloc.c: exit=$direct_code_gc_alloc: $direct_err_gc_alloc"
+                echo "hello.c: exit=$direct_code_hello: $direct_err_hello"
+                exit 1
+              fi
               ;;
             *)
               echo "::error::Static libgc.a lane failed, but NOT with the known/expected signature (PASS crash, FAIL gc_alloc/hello with compile error) - this looks like a different, unexpected problem and should not be silently treated as the known XFAIL."
@@ -207,28 +313,23 @@ jobs:
               ;;
           esac
 
-      # actions/upload-artifact doesn't preserve executable bits on raw
-      # files (tcc.exe would come back chmod 644 after download), and
-      # hand-listing individual paths already missed lib/libtcc1.a -
-      # which tcc.exe needs at link time just as much as libgc. Archive
-      # the whole rebuilt thirdparty/tcc output instead: tar preserves
-      # modes, and keeping the thirdparty/tcc/ prefix inside the
-      # archive means extracting it anywhere reproduces the exact
-      # relative layout tcc.exe's own baked-in library path expects
-      # (see the comment on the "run shared conformance tests" step
-      # above) - a raw multi-path upload-artifact list would instead
-      # flatten that prefix away.
-      - name: package built tcc for upload
-        # Run even after an earlier failure, so a maintainer debugging
-        # a red run still gets a downloadable build to reproduce
-        # against instead of just a log transcript.
-        if: ${{ !cancelled() }}
-        working-directory: work
-        run: tar --exclude=.git -czf tccbin-macos-arm64-current.tar.gz thirdparty/tcc
-
-      - name: upload built binaries
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: tccbin-macos-arm64-current
-          path: work/tccbin-macos-arm64-current.tar.gz
+  tccbin-branch-gate:
+    name: tccbin-branch-gate
+    if: >-
+      always() &&
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-macos-arm64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-macos-arm64')
+      )
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: require successful baseline validation
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: test "$BUILD_RESULT" = success

--- a/automation/bundle-manifest.json
+++ b/automation/bundle-manifest.json
@@ -1,0 +1,1115 @@
+{
+  "schema_version": 1,
+  "contract_version": 1,
+  "contract_repository": "vlang/v",
+  "contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "contract_mode": "production",
+  "v_source_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "target_id": "macos-arm64",
+  "branch": "thirdparty-macos-arm64",
+  "sources": [
+    {
+      "id": "tinycc",
+      "repository": "https://repo.or.cz/tinycc.git",
+      "ref": "mob",
+      "sha": null,
+      "tree": null
+    },
+    {
+      "id": "bdwgc",
+      "repository": "https://github.com/ivmai/bdwgc.git",
+      "ref": "master",
+      "sha": null,
+      "tree": null
+    },
+    {
+      "id": "libatomic_ops",
+      "repository": "https://github.com/bdwgc/libatomic_ops.git",
+      "ref": "master",
+      "sha": null,
+      "tree": null
+    }
+  ],
+  "recipe": {
+    "path": "build.sh",
+    "version": 1,
+    "sha256": "9d404906360053a84c9dd582ea077c813dcffa90470e93c0948c53882f7ab8df"
+  },
+  "toolchain": {
+    "profile_id": null,
+    "profile_sha256": null,
+    "producer_observation": null
+  },
+  "patches": [],
+  "transforms": [],
+  "header_effects": [],
+  "integrations": [],
+  "overlays": [],
+  "inventory": [
+    {
+      "path": ".gitignore",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4600d1eadad61579d602f7b4cd4f1c13a7a989e112c119d766204df1bf1f993c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "README.md",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2061140e0452f19caca1967d2eaef14dbdaa992bc3f44d7ec7b35cad72e3d70c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e270b56ca7e6780354f35b656ee6485a55194f62b90f5e332e4f144310d76fc0",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "26d30397439e29c1615fc33cb250a666420425e58533bd57f5b5950897ecfcce",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "cbc5e7d0a22103555385be4076566b25e22adbe198089ce7404e50d2c75aa97e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_version.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "48ea21824450117f62d8740199f4966a177569a16888ac626c9ba32ad66a5b00",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "include/libtcc.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "42e1fb86b44088850e0e17ec0947b483a2edb586b420d18196d7b9b5dce944e4",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/bcheck.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d7e877d7095e2f454b9fc0638449574628c88c9271152b2b4f781245cc88edfe",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/bt-exe.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4c161e2df3d1e10f14cd31b28ac8178a3b4aac60cba7fef63fc36389a0723d43",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/bt-log.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c6369a5e26207c7c1758faa2dd5dae999f4af5ae9b662f7d30efb2a359fe4ce3",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/build_make_script_work_consistently",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/float.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "484ffee95fcdbc00cdc154b9dc2fe03fed65610bf1a73b610871cc39698e6f8e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdalign.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7612d46571099ccaa7616a510f78f180cb1e91671e6e5e9223a2e297b84b789d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdarg.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a38f8d34f5e09658cc3a8892b3a7e80ff566eaeedc194e5a85ece0b675993137",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdatomic.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4fbd9d6ec9add338d41c06f44115121925f087dd91f445b56cca1aacb84360e1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdbool.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "5252824225ddc486b0460677f765e4157af5d3ed7acd65b310a4045eafb56af7",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stddef.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c42eaa62f574527b8d0d64f802b20c27ebeb66feb2c3608e9b9659225ad6ed45",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdnoreturn.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ec64d8fbf7fb2e800df9784b2efca0a99fc25a3eb5e8da56e4df098937f787f2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/tccdefs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d1016b6170c45f1b8e7f8d83bf1f00f21e288eb2e446d9f141457f6f821acf7b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/tcclib.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2cfbd6b9c5e039721fbfb8e6f95a0a9fc30597bbcb2aefa3dda572c278009429",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/tgmath.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e60c66ff9017f13ab18ee38824792ca771b9235bcb4df57688fec582739524a5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/varargs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "07858857f4eed0a61df94beb1a9d678b53fc3d67a0b0e8936155f85ddbcd1dcc",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libc.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "e7bcb0d6952965edf7ac86d2e8e787b12f191ae1b284614ded3958a824ab5cab",
+      "symlink_target": "/System/DriverKit/usr/lib/libSystem.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.1.dylib",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "8ead17832cc3ca1bd9141e8ed79472fd68d2146015a1ed53e3b390d26d0b6fe0",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "82871c4e2ca0054ac0cb558fd982e3fb8f19a8000763835ff4795f96396c50ca",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "a585a7bbd2be5ca3e0878d1cd1421ef322692d9e31b0da70a92e34a7c9bf52a9",
+      "symlink_target": "libgc.1.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.la",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "d9a987dc013fd03f5d814955ea8003259500aa0a7d5a0f21abf995dfe5c40390",
+      "symlink_target": "../libgc.la",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.lai",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "9d04cfc8e3a063b74730b452ffc79e217e85109cbdc916e83817bd26930a5f9a",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_cmd.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ed5550b6d8369b948b8ad68e5f7e703df951d49c8b3ab72bb6234ae19f2529b1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "95f2ab9fb6d89ddb5c524d5010c01ce3c727d00944a321540b0ce5a2ee359939",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "53c9aa33f693f24e5ec9a0fea42ac978579dbe0d70b26639b1682696412f666f",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "69b6fa79ced441fbe3d821a3726669de4e4c6ff984657637952997b8d2536fae",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.1.dylib",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "ee8546661c2679fc3438a768128f0579db4f083f5d5aecd9a69c6d55eea26265",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "96a93fa84fee1aec6ac57acd7e9177d44866fb2c978e6ea6c4287a94abc49e1c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "82754ba227ddfd52a128cdce9b353048d0cf5ec3ea7ceebeee01dbee21016da9",
+      "symlink_target": "libgccpp.1.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.la",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "14b96cc582652e5145f517fd978778fedc420fc2c6ed7b1ea9e0fac7f6b87b41",
+      "symlink_target": "../libgccpp.la",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.lai",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "5b74331caacc9a0a0601a0981f8a6395c040152c4aeaedaf936d13f0b0791d99",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.1.dylib",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "954667fb09eb80bac4a8b95b49bb3ffb1c9e4416cf7da51d8137b08e618efcc9",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "99c8fe42f68ffaaf90676911fb186c6a1968ab16d67ce7a98e13a0fd27e8d888",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "31e383001e01134ee678744fe9c4e5faafd58fef6f3629d6b20d306abc994dfa",
+      "symlink_target": "libgctba.1.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.la",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "36177136d3e5be65b6227b3997a63a502a5acc7c882122317bd7537acb02cb66",
+      "symlink_target": "../libgctba.la",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.lai",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "551f7e342f3c7352cd5de915ae30ce73d8a446419fc11d46051fdc9c31ebb710",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "84320aebf433b2f21ca1be99e331e67d7d213922400d3f5975d4238396d50d8a",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc1.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "3971b76159655b7947b4e9d43266538dc46b23a9025df93b3990ad851a8b285b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/runmain.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "90a367afe4693e1aa330557ce16a4d3ad0f7c055fc11288c7ad33cf06d0c21e1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/man/man1/tcc.1",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "20926877dc596cd2a6c91ac2488d9b4608d9cfeebf381cf3bbbae341e480ba25",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "outputs": [
+    {
+      "path": "tcc.exe",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "63d6696349fc3cbd1905e89e60fb169e6d2904036c625867c087a9f030bea5c5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "native-compiler",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "probes": [
+    {
+      "id": "manifest-contract",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "strict schema, binding, and semantic validation"
+    },
+    {
+      "id": "source-provenance",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "unresolved sources remain explicitly non-publishable"
+    },
+    {
+      "id": "native-build",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "native build succeeds"
+    },
+    {
+      "id": "payload-inventory",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "manifest inventory is expanded before eligibility"
+    },
+    {
+      "id": "patch-probes",
+      "required": true,
+      "expected_lanes": [],
+      "oracle": "empty patchset materializes one expected-zero result"
+    },
+    {
+      "id": "tccbin-conformance",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "shared conformance passes"
+    },
+    {
+      "id": "v-no-fallback-smoke",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "V uses the selected compiler without fallback"
+    },
+    {
+      "id": "artifact-digests",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "declared output digests match"
+    },
+    {
+      "id": "publish-preflight-dry-run",
+      "required": true,
+      "expected_lanes": [
+        "arm64"
+      ],
+      "oracle": "publish remains false"
+    }
+  ],
+  "provenance_status": "incomplete",
+  "affected_targets": [
+    "macos-arm64"
+  ]
+}

--- a/automation/probes/baseline-contract.sh
+++ b/automation/probes/baseline-contract.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+export LC_ALL=C
+
+readonly expected_contract_repository='vlang/v'
+
+if [[ $# -ne 8 ]]; then
+	printf '%s\n' 'usage: baseline-contract.sh <validator> <contract-root> <bundle-root> <target-id> <canonical-branch> <contract-sha> <bundle-sha> <vc-root>' >&2
+	exit 2
+fi
+
+validator=$1
+contract_root=$2
+bundle_root=$3
+target_id=$4
+canonical_branch=$5
+expected_contract_sha=$6
+bundle_sha=$7
+vc_root=$8
+manifest="$bundle_root/automation/bundle-manifest.json"
+schema="$contract_root/thirdparty/tccbin_automation/schemas/bundle-manifest.schema.json"
+
+[[ -x "$validator" && -d "$contract_root" && -d "$bundle_root" && -d "$vc_root" ]] || exit 1
+[[ -f "$manifest" && ! -L "$manifest" && -f "$schema" && ! -L "$schema" ]] || exit 1
+[[ "$expected_contract_sha" =~ ^[0-9a-f]{40}$ && "$bundle_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
+
+validator_command() {
+	(cd -P -- "$contract_root" && "$validator" "$@")
+}
+
+case "${PUBLISH:-false}:${TCCBIN_PUBLISH:-false}" in
+	false:false | 0:0 | false:0 | 0:false) ;;
+	*) printf '%s\n' 'baseline contract probe refuses publication' >&2; exit 1 ;;
+esac
+
+binding=$(validator_command contract-binding)
+[[ "$binding" == "repository=$expected_contract_repository sha=$expected_contract_sha" ]] || {
+	printf '%s\n' 'validator contract binding mismatch' >&2
+	exit 1
+}
+
+validator_command contract >/dev/null
+[[ "$(validator_command validate "$schema" "$manifest")" == 'valid' ]]
+canonical=$(validator_command canonicalize "$manifest")
+
+for exact_member in \
+	"\"contract_repository\":\"$expected_contract_repository\"" \
+	"\"contract_sha\":\"$expected_contract_sha\"" \
+	'"contract_mode":"production"' \
+	"\"v_source_sha\":\"$expected_contract_sha\"" \
+	"\"target_id\":\"$target_id\"" \
+	"\"branch\":\"$canonical_branch\"" \
+	'"provenance_status":"incomplete"'; do
+	case "$canonical" in
+		*"$exact_member"*) ;;
+		*) printf '%s\n' 'manifest baseline binding mismatch' >&2; exit 1 ;;
+	esac
+done
+
+fingerprints=$(validator_command fingerprint "$manifest")
+[[ $(printf '%s\n' "$fingerprints" | wc -l | tr -d ' ') == 3 ]]
+for key in manifest_hash input_fingerprint artifact_fingerprint; do
+	value=$(printf '%s\n' "$fingerprints" | sed -n "s/^${key}=//p")
+	[[ "$value" =~ ^[0-9a-f]{64}$ ]]
+done
+
+[[ "$(git -C "$bundle_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$bundle_root" rev-parse HEAD)" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" rev-parse --verify "${bundle_sha}^{commit}")" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" symbolic-ref -q HEAD || true)" == '' ]]
+[[ "$(git -C "$bundle_root" status --porcelain=v1 --untracked-files=all --ignored=matching)" == '' ]]
+
+staging_parent=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+staging_root=$(mktemp -d "$staging_parent/tccbin-payload.XXXXXX")
+cleanup_paths=("$staging_root")
+linked_bundle=false
+for generated_v in v1 v2 v v1.exe v2.exe v.exe; do
+	[[ ! -e "$contract_root/$generated_v" && ! -L "$contract_root/$generated_v" ]]
+done
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+	if [[ "$linked_bundle" == true ]]; then
+		rm -rf -- "$contract_root/thirdparty/tcc"
+	fi
+	rm -f -- "$contract_root/v1" "$contract_root/v2" "$contract_root/v" \
+		"$contract_root/v1.exe" "$contract_root/v2.exe" "$contract_root/v.exe"
+	for cleanup_path in "${cleanup_paths[@]}"; do
+		[[ -n "$cleanup_path" && -d "$cleanup_path" ]] && rm -rf -- "$cleanup_path"
+	done
+	exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+git -C "$bundle_root" archive --format=tar "$bundle_sha" | tar -xf - -C "$staging_root"
+rm -rf -- "$staging_root/.github" "$staging_root/automation"
+case "$target_id" in
+	windows-amd64)
+		rm -f -- \
+			"$staging_root/build.ps1" \
+			"$staging_root/0001-tccpe-strip-quotes-and-default-.dll-extension-in-DEF.patch" \
+			"$staging_root/0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch" \
+			"$staging_root/0003-win32-declare-CreateSymbolicLink.patch" \
+			"$staging_root/0004-win32-declare-WSAConnectBy-family.patch" \
+			"$staging_root/0005-win32-declare-InetNtop-InetPton-family.patch" \
+			"$staging_root/0006-win32-declare-shell-drag-drop-family.patch" \
+			"$staging_root/0007-win32-declare-secure-narrow-stdio.patch" \
+			"$staging_root/0008-win32-fix-exp2-range-reduction.patch" \
+			"$staging_root/0009-win32-declare-CancelIoEx.patch" \
+			"$staging_root/vlang-header-compat.patch" \
+			"$staging_root/v-ae88ee5-tinycc-bdwgc.patch"
+		;;
+	linux-amd64 | macos-amd64 | macos-arm64 | freebsd-amd64 | openbsd-amd64)
+		rm -f -- "$staging_root/build.sh"
+		;;
+	*) printf '%s\n' 'unknown target for payload staging' >&2; exit 1 ;;
+esac
+
+staged_result=$(validator_command staged-preflight \
+	"$manifest" "$staging_root" "$bundle_root" "$bundle_sha" false)
+readonly expected_staged_result='eligible=false reason=staged_provenance_incomplete publish_allowed=false manifest_hash= input_fingerprint= artifact_fingerprint='
+[[ "$staged_result" == "$expected_staged_result" ]] || {
+	printf 'unexpected staged preflight result: %s\n' "$staged_result" >&2
+	exit 1
+}
+
+[[ "$(git -C "$contract_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$vc_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$contract_root" rev-parse HEAD)" == "$expected_contract_sha" ]]
+vc_sha=$(sed -n 's/^commit=//p' "$contract_root/thirdparty/tccbin_automation/bootstrap/vc.lock")
+[[ "$vc_sha" =~ ^[0-9a-f]{40}$ && "$(git -C "$vc_root" rev-parse HEAD)" == "$vc_sha" ]]
+
+contract_tcc="$contract_root/thirdparty/tcc"
+if [[ -e "$contract_tcc" || -L "$contract_tcc" ]]; then
+	[[ "$(cd -P -- "$contract_tcc" && pwd)" == "$(cd -P -- "$bundle_root" && pwd)" ]]
+else
+	ln -s "$bundle_root" "$contract_tcc"
+	linked_bundle=true
+fi
+
+case "$target_id" in
+	windows-amd64)
+		cc_name=${CC:-gcc}
+		exe_suffix=.exe
+		;;
+	*)
+		cc_name=${CC:-cc}
+		exe_suffix=
+		;;
+esac
+cc_path=$(command -v -- "$cc_name")
+[[ "$cc_path" == /* && -x "$cc_path" ]]
+
+if [[ "$target_id" == windows-amd64 ]]; then
+	"$cc_path" -std=c99 -municode -w -o "$contract_root/v1.exe" "$vc_root/v_win.c" \
+		-ladvapi32 -lws2_32 -Wl,-stack=33554432
+	(
+		cd -P -- "$contract_root"
+		./v1.exe -no-parallel -nocache -cc "$cc_path" -o ./v2.exe -gc none cmd/v
+		./v2.exe -no-parallel -nocache -cc "$cc_path" -o ./v.exe -gc none cmd/v
+	)
+else
+	link_flags=(-lm -lpthread)
+	case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			link_flags+=(-lexecinfo)
+			;;
+	esac
+	"$cc_path" -std=c99 -w -o "$contract_root/v1" "$vc_root/v.c" "${link_flags[@]}"
+	(
+		cd -P -- "$contract_root"
+		case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none \
+				-ldflags -lexecinfo cmd/v
+			./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none \
+				-ldflags -lexecinfo cmd/v
+			;;
+		*)
+			./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none cmd/v
+			./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none cmd/v
+			;;
+		esac
+	)
+fi
+
+smoke_root=$(mktemp -d "$staging_parent/tccbin-v-smoke.XXXXXX")
+cleanup_paths+=("$smoke_root")
+cat > "$smoke_root/main.v" <<'VEOF'
+module main
+
+fn main() {
+	println('tccbin-v-smoke')
+}
+VEOF
+smoke_binary="$smoke_root/tccbin-v-smoke${exe_suffix}"
+if ! showcc_output=$(
+	cd -P -- "$contract_root"
+	"./v${exe_suffix}" -cc tcc -gc none -showcc -no-retry-compilation -no-rsp \
+		-o "$smoke_binary" "$smoke_root/main.v" 2>&1
+); then
+	printf '%s\n' "$showcc_output" >&2
+	exit 1
+fi
+printf '%s\n' "$showcc_output"
+if printf '%s\n' "$showcc_output" | grep -Eiq \
+	'falling back to|retrying with|fallback compiler|backup compiler'; then
+	printf '%s\n' 'V attempted a compiler fallback' >&2
+	exit 1
+fi
+normalized_showcc=$(printf '%s\n' "$showcc_output" | tr '\\' '/')
+case "$normalized_showcc" in
+	*'/thirdparty/tcc/tcc.exe'*) ;;
+	*) printf '%s\n' 'V did not report the bundled tcc.exe command' >&2; exit 1 ;;
+esac
+[[ -f "$smoke_binary" ]]
+[[ "$($smoke_binary)" == 'tccbin-v-smoke' ]]
+
+printf 'tccbin baseline contract target=%s staged=incomplete smoke=v-tcc publish=false: PASS\n' "$target_id"


### PR DESCRIPTION
## Summary

This PR adds the Phase A read-only automation baseline for the macOS ARM64 tccbin bundle and binds it to the merged `vlang/v` automation contract.

It adds an immutable bundle manifest, contract and provenance validation, a no-fallback V smoke test, and the existing native conformance checks behind a single branch gate.

## Why

The goal is to make future tccbin updates reproducible and auditable, while rejecting stale, incomplete, or unverified candidates before they can reach a publication path.

## Safety

This PR does not enable publication. Provenance remains incomplete, `PUBLISH` and `TCCBIN_PUBLISH` stay disabled, and the workflow has no secrets, artifact uploads, or Git push capability.