### PR TITLE
ci: add openbsd-amd64 tccbin automation baseline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,104 +5,148 @@ on:
     branches: [thirdparty-openbsd-amd64]
   pull_request:
     branches: [thirdparty-openbsd-amd64]
-  workflow_dispatch: {}
+
+permissions:
+  contents: read
 
 jobs:
   build:
+    name: openbsd-amd64 read-only validation
+    if: >-
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-openbsd-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-openbsd-amd64')
+      )
     runs-on: ubuntu-latest
-    # For a pull_request event, clone the PR's own head repo+commit (so a
-    # PR that updates tcc.exe/libgc.a is actually tested) instead of the
-    # unrelated target branch's current tip - a hardcoded
-    # `git clone --branch thirdparty-openbsd-amd64 .../vlang/tccbin.git`
-    # would silently test only the already-merged target branch
-    # regardless of what the PR proposes. push/workflow_dispatch have no
-    # PR context, so they fall back to the event's own repository/commit
-    # (not a branch *name*, which is mutable: another push landing while
-    # this run is queued/starting would otherwise make TCCBIN_CLONE_SHA's
-    # predecessor, a ref name, silently resolve to a different commit
-    # than the one that triggered this run - Codex pullrequestreview-
-    # 4780049532 on vlang/tccbin#76). Set at job level (matching
-    # update_tccbin.yml's own working BSD job env, which only ever
-    # references github.*/secrets.*, never steps.* - step-level env on
-    # the "Start VM" step was tried first and empirically did NOT get
-    # forwarded into the VM by environment_variables, unlike this
-    # job-level placement).
+    timeout-minutes: 60
     env:
-      TCCBIN_CLONE_URL: ${{ github.event.pull_request.head.repo.clone_url || github.event.repository.clone_url }}
-      TCCBIN_CLONE_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      TARGET_ID: openbsd-amd64
+      CANONICAL_BRANCH: thirdparty-openbsd-amd64
+      TCCBIN_CLONE_URL: https://github.com/vlang/tccbin
+      TCCBIN_CLONE_SHA: ${{ github.sha }}
+      CONTRACT_REPOSITORY: vlang/v
+      CONTRACT_CLONE_URL: https://github.com/vlang/v
+      CONTRACT_SHA: 7545e515b434cd399333d43659238427d72e22e7
+      VC_CLONE_URL: https://github.com/vlang/vc
+      VC_SHA: dfc458a13ba8923ebc249e262c331f8169aa728b
+      PUBLISH: 'false'
+      TCCBIN_PUBLISH: 'false'
     steps:
-      # cross-platform-actions/action boots a real OpenBSD VM inside this
-      # Linux runner - the same action vlang/v's own update_tccbin.yml
-      # uses to rebuild this branch's binaries. Pinned to the v1.3.0
-      # tag's commit (resolved via the GitHub API) rather than the
-      # mutable tag itself, so a retag upstream can't silently swap in
-      # different third-party code here without a review-visible diff
-      # (Codex pullrequestreview-4780049532 on vlang/tccbin#76).
       - name: Start openbsd-amd64 VM
-        uses: cross-platform-actions/action@4347c661239bf5dcd0cd77708061488d907343d6 # v1.3.0
+        uses: cross-platform-actions/action@24ef01df165c76df1ed2b9f9e9212e78dc2fc963 # v1.4
         with:
           operating_system: openbsd
           version: '7.8'
           memory: 4G
           shell: sh
           sync_files: runner-to-vm
-          environment_variables: TCCBIN_CLONE_URL TCCBIN_CLONE_SHA
+          environment_variables: >-
+            TARGET_ID CANONICAL_BRANCH
+            TCCBIN_CLONE_URL TCCBIN_CLONE_SHA
+            CONTRACT_REPOSITORY CONTRACT_CLONE_URL CONTRACT_SHA
+            VC_CLONE_URL VC_SHA PUBLISH TCCBIN_PUBLISH
 
-      - name: run shared conformance tests
-        shell: cpa.sh {0}
+      - name: Bootstrap immutable contract and run baseline probe
+        shell: cpa.sh {0} --sync-files none
         run: |
           set -eu
-          sudo pkg_add bash git
+          umask 077
+          sudo pkg_add bash git boehm-gc
 
-          # This branch (unlike linux-amd64/macos-arm64/freebsd-amd64)
-          # ships no libgc.a/.dylib at all - confirmed by inspecting its
-          # tree, and matching V's own builder
-          # (vlib/builtin/builtin_d_gcboehm.c.v's openbsd+tinyc branch),
-          # which only ever references /usr/local/lib/libgc.a, never a
-          # bundled path, for this exact platform+compiler combination.
-          # GC-dependent tests need a system-installed libgc instead.
-          # OpenBSD's port for this is devel/boehm-gc (confirmed via
-          # cvsweb.openbsd.org/ports/devel/) - package name is boehm-gc,
-          # not libgc or gc.
-          sudo pkg_add boehm-gc
+          test "$PUBLISH" = false
+          test "$TCCBIN_PUBLISH" = false
+          test "$CONTRACT_REPOSITORY" = vlang/v
+          test "$CONTRACT_CLONE_URL" = "https://github.com/$CONTRACT_REPOSITORY"
+          test "$VC_CLONE_URL" = https://github.com/vlang/vc
 
-          # Fetch the exact commit that triggered this run, not a branch
-          # name - `git clone --branch <name>` would resolve whatever
-          # that name points to *at clone time*, which can race a push
-          # that lands after this run started (Codex pullrequestreview-
-          # 4780049532 on vlang/tccbin#76).
-          mkdir -p thirdparty/tcc && cd thirdparty/tcc
-          git init -q
-          git remote add origin "$TCCBIN_CLONE_URL"
-          git fetch --depth=1 origin "$TCCBIN_CLONE_SHA"
-          git checkout -q FETCH_HEAD
-          cd ../..
+          checkout_exact() {
+            checkout_repository=$1
+            checkout_sha=$2
+            checkout_destination=$3
+            checkout_history=$4
 
-          # thirdparty/libgc/include (gc.h) and thirdparty/tccbin_tests
-          # (the shared cross-platform conformance suite) both live in
-          # the main v repo, not here. A plain `git clone --depth=1`
-          # only ever contains the CURRENT tip commit's objects - once
-          # vlang/v advances past this pinned SHA, that historical
-          # commit object won't exist in a fresh shallow clone and this
-          # checkout would fail (the same class of bug Codex flagged as
-          # P1 on the sibling freebsd-amd64 workflow, pullrequestreview-
-          # 4780048339 on vlang/tccbin#75 line 60). Fetch that exact SHA
-          # directly instead of cloning HEAD and hoping it's still there.
-          mkdir -p vsrc && cd vsrc
-          git init -q
-          git remote add origin https://github.com/vlang/v.git
-          git sparse-checkout init --no-cone
-          git sparse-checkout set thirdparty/libgc thirdparty/tccbin_tests
-          git fetch --filter=blob:none --depth=1 origin c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
-          git checkout -q FETCH_HEAD
-          cd ..
+            test "${#checkout_sha}" -eq 40
+            case "$checkout_sha" in
+              *[!0-9a-f]*) exit 1 ;;
+            esac
+            test ! -e "$checkout_destination"
+            mkdir -p "$checkout_destination"
+            git -C "$checkout_destination" init -q
+            git -C "$checkout_destination" config --local core.autocrlf false
+            git -C "$checkout_destination" remote add origin "$checkout_repository"
+            if test "$checkout_history" = shallow; then
+              GIT_TERMINAL_PROMPT=0 git -C "$checkout_destination" \
+                fetch --no-tags --depth=1 origin "$checkout_sha"
+            else
+              GIT_TERMINAL_PROMPT=0 git -C "$checkout_destination" \
+                fetch --no-tags origin "$checkout_sha"
+            fi
+            git -C "$checkout_destination" checkout -q --detach FETCH_HEAD
+            test "$(git -C "$checkout_destination" rev-parse HEAD)" = "$checkout_sha"
+            if test "$checkout_history" = full; then
+              test "$(git -C "$checkout_destination" \
+                rev-parse --is-shallow-repository)" = false
+            fi
+          }
 
-          chmod +x thirdparty/tcc/tcc.exe
+          mkdir -p "$PWD/thirdparty"
+          checkout_exact "$TCCBIN_CLONE_URL" "$TCCBIN_CLONE_SHA" \
+            "$PWD/thirdparty/tcc" shallow
+          checkout_exact "$CONTRACT_CLONE_URL" "$CONTRACT_SHA" \
+            "$PWD/vsrc" full
 
-          # The bundled tcc.exe resolves its own crt/libtcc1.a via a path
-          # relative to the process's working directory (confirmed on
-          # linux-amd64/macos-arm64/freebsd-amd64's CI).
-          bash vsrc/thirdparty/tccbin_tests/run.sh "$PWD/thirdparty/tcc/tcc.exe" openbsd -- \
+          contract_work="$(mktemp -d "${TMPDIR:-/tmp}/tccbin-contract.XXXXXX")"
+          vc_root="$contract_work/vc"
+          validator_work="$contract_work/validator"
+          checkout_exact "$VC_CLONE_URL" "$VC_SHA" "$vc_root" full
+
+          bash "$PWD/vsrc/thirdparty/tccbin_automation/bootstrap/bootstrap.sh" \
+            "$PWD/vsrc" "$CONTRACT_REPOSITORY" "$CONTRACT_SHA" \
+            "$vc_root" "$validator_work"
+
+          test -x "$validator_work/tccbin-automation"
+          test -d "$validator_work/contract-source"
+          chmod +x "$PWD/thirdparty/tcc/tcc.exe"
+          PUBLISH=false TCCBIN_PUBLISH=false \
+            bash "$PWD/thirdparty/tcc/automation/probes/baseline-contract.sh" \
+              "$validator_work/tccbin-automation" \
+              "$validator_work/contract-source" \
+              "$PWD/thirdparty/tcc" \
+              "$TARGET_ID" "$CANONICAL_BRANCH" "$CONTRACT_SHA" \
+              "$TCCBIN_CLONE_SHA" "$vc_root"
+
+      - name: run shared conformance tests
+        shell: cpa.sh {0} --sync-files none
+        run: |
+          set -eu
+          bash vsrc/thirdparty/tccbin_tests/run.sh \
+              "$PWD/thirdparty/tcc/tcc.exe" openbsd -- \
               -DGC_BUILTIN_ATOMIC=1 \
               -I "$PWD/vsrc/thirdparty/libgc/include" \
               -L/usr/local/lib -I/usr/local/include -lgc -lpthread
+
+  tccbin-branch-gate:
+    name: tccbin-branch-gate
+    if: >-
+      always() &&
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-openbsd-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-openbsd-amd64')
+      )
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: require successful OpenBSD validation
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          set -euo pipefail
+          test "$BUILD_RESULT" = success

--- a/automation/bundle-manifest.json
+++ b/automation/bundle-manifest.json
@@ -1,0 +1,681 @@
+{
+  "schema_version": 1,
+  "contract_version": 1,
+  "contract_repository": "vlang/v",
+  "contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "contract_mode": "production",
+  "v_source_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "target_id": "openbsd-amd64",
+  "branch": "thirdparty-openbsd-amd64",
+  "sources": [
+    {
+      "id": "tinycc",
+      "repository": "https://repo.or.cz/tinycc.git",
+      "ref": "mob",
+      "sha": null,
+      "tree": null
+    }
+  ],
+  "recipe": {
+    "path": "build.sh",
+    "version": 1,
+    "sha256": "9a0de2a75b7f025d6b9f16302f0b0ff2e623eb1ee86fdb1468be5545905759cb"
+  },
+  "toolchain": {
+    "profile_id": null,
+    "profile_sha256": null,
+    "producer_observation": null
+  },
+  "patches": [],
+  "transforms": [],
+  "header_effects": [],
+  "integrations": [],
+  "overlays": [],
+  "inventory": [
+    {
+      "path": "README.md",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "963a6b97d84e3eff0b4374ce020600690a600bcc869f91a0dc7513dd0f49a5f2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "be65a2097caf6573cd929c88db13e63d73579cb5c03218a37b52bc21ec4ac85e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "996a57d245226c9adfbafd0dcdf9f824d438bffee91b5a0fbfdc6bfc8b23501c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "cbc5e7d0a22103555385be4076566b25e22adbe198089ce7404e50d2c75aa97e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_version.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "8b40ef89cd404998566c33adf65d67b2504362acafc876504ee4f2c3765750a7",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "include/libtcc.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "42e1fb86b44088850e0e17ec0947b483a2edb586b420d18196d7b9b5dce944e4",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "f5921ddcdc6ffba29359e7d6ab3644ce67b0143fde0e951d4aaff3306965dfc2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bcheck.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e2ec079c848486dac280792a294348694a2d886c94460cbebe013df69a2d554a",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bt-exe.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "dc064268aca3a4128ff50f6cd72ec71bc03fc2a0711607a63ba1477871077e12",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/bt-log.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d77fcb2c48b731fe09c35ce11cfc0df6034b4bc34bed1e69c005c5bf13c0c8aa",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/float.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "484ffee95fcdbc00cdc154b9dc2fe03fed65610bf1a73b610871cc39698e6f8e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdalign.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7612d46571099ccaa7616a510f78f180cb1e91671e6e5e9223a2e297b84b789d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdarg.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a38f8d34f5e09658cc3a8892b3a7e80ff566eaeedc194e5a85ece0b675993137",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdatomic.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4fbd9d6ec9add338d41c06f44115121925f087dd91f445b56cca1aacb84360e1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdbool.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "5252824225ddc486b0460677f765e4157af5d3ed7acd65b310a4045eafb56af7",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stddef.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c42eaa62f574527b8d0d64f802b20c27ebeb66feb2c3608e9b9659225ad6ed45",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/stdnoreturn.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ec64d8fbf7fb2e800df9784b2efca0a99fc25a3eb5e8da56e4df098937f787f2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tccdefs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d1016b6170c45f1b8e7f8d83bf1f00f21e288eb2e446d9f141457f6f821acf7b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tcclib.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2cfbd6b9c5e039721fbfb8e6f95a0a9fc30597bbcb2aefa3dda572c278009429",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/tgmath.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e60c66ff9017f13ab18ee38824792ca771b9235bcb4df57688fec582739524a5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/include/varargs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "07858857f4eed0a61df94beb1a9d678b53fc3d67a0b0e8936155f85ddbcd1dcc",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/libtcc1.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "439554d2bfbbd05e3dfa1cda93d5161a5a2cdbfb5aab84dc20142d5083688501",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/tcc/runmain.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "83ec3ed78acf7e310690195edcc5de3c2d5b47c157f560f53a40ce1f15548098",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/doc/tcc-doc.html",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "42397b1ff3b711c3619b3d20d4704401b93d465110bf4bd8923a4dfad6360317",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/info/tcc-doc.info",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "350d0744e2d0d1057ac09381285ea2a7460b9bb9c7b6050f0d669d155914e06e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/man/man1/tcc.1",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "edb8f4f63ef2652c5856745e72bf51b695bfec239073608c5b87a2ec4a122871",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "outputs": [
+    {
+      "path": "tcc.exe",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "beb0ced522d21ddd4658e6600296127b55354f825e69f37da4979ed47bf590a5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "native-compiler",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "probes": [
+    {
+      "id": "manifest-contract",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "strict schema, binding, and semantic validation"
+    },
+    {
+      "id": "source-provenance",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "unresolved sources remain explicitly non-publishable"
+    },
+    {
+      "id": "native-build",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "native build succeeds"
+    },
+    {
+      "id": "payload-inventory",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "manifest inventory is expanded before eligibility"
+    },
+    {
+      "id": "patch-probes",
+      "required": true,
+      "expected_lanes": [],
+      "oracle": "empty patchset materializes one expected-zero result"
+    },
+    {
+      "id": "tccbin-conformance",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "shared conformance passes"
+    },
+    {
+      "id": "v-no-fallback-smoke",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "V uses the selected compiler without fallback"
+    },
+    {
+      "id": "artifact-digests",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "declared output digests match"
+    },
+    {
+      "id": "publish-preflight-dry-run",
+      "required": true,
+      "expected_lanes": [
+        "native"
+      ],
+      "oracle": "publish remains false"
+    }
+  ],
+  "provenance_status": "incomplete",
+  "affected_targets": [
+    "openbsd-amd64"
+  ]
+}

--- a/automation/probes/baseline-contract.sh
+++ b/automation/probes/baseline-contract.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+export LC_ALL=C
+
+readonly expected_contract_repository='vlang/v'
+
+if [[ $# -ne 8 ]]; then
+	printf '%s\n' 'usage: baseline-contract.sh <validator> <contract-root> <bundle-root> <target-id> <canonical-branch> <contract-sha> <bundle-sha> <vc-root>' >&2
+	exit 2
+fi
+
+validator=$1
+contract_root=$2
+bundle_root=$3
+target_id=$4
+canonical_branch=$5
+expected_contract_sha=$6
+bundle_sha=$7
+vc_root=$8
+manifest="$bundle_root/automation/bundle-manifest.json"
+schema="$contract_root/thirdparty/tccbin_automation/schemas/bundle-manifest.schema.json"
+
+[[ -x "$validator" && -d "$contract_root" && -d "$bundle_root" && -d "$vc_root" ]] || exit 1
+[[ -f "$manifest" && ! -L "$manifest" && -f "$schema" && ! -L "$schema" ]] || exit 1
+[[ "$expected_contract_sha" =~ ^[0-9a-f]{40}$ && "$bundle_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
+
+validator_command() {
+	(cd -P -- "$contract_root" && "$validator" "$@")
+}
+
+case "${PUBLISH:-false}:${TCCBIN_PUBLISH:-false}" in
+	false:false | 0:0 | false:0 | 0:false) ;;
+	*) printf '%s\n' 'baseline contract probe refuses publication' >&2; exit 1 ;;
+esac
+
+binding=$(validator_command contract-binding)
+[[ "$binding" == "repository=$expected_contract_repository sha=$expected_contract_sha" ]] || {
+	printf '%s\n' 'validator contract binding mismatch' >&2
+	exit 1
+}
+
+validator_command contract >/dev/null
+[[ "$(validator_command validate "$schema" "$manifest")" == 'valid' ]]
+canonical=$(validator_command canonicalize "$manifest")
+
+for exact_member in \
+	"\"contract_repository\":\"$expected_contract_repository\"" \
+	"\"contract_sha\":\"$expected_contract_sha\"" \
+	'"contract_mode":"production"' \
+	"\"v_source_sha\":\"$expected_contract_sha\"" \
+	"\"target_id\":\"$target_id\"" \
+	"\"branch\":\"$canonical_branch\"" \
+	'"provenance_status":"incomplete"'; do
+	case "$canonical" in
+		*"$exact_member"*) ;;
+		*) printf '%s\n' 'manifest baseline binding mismatch' >&2; exit 1 ;;
+	esac
+done
+
+fingerprints=$(validator_command fingerprint "$manifest")
+[[ $(printf '%s\n' "$fingerprints" | wc -l | tr -d ' ') == 3 ]]
+for key in manifest_hash input_fingerprint artifact_fingerprint; do
+	value=$(printf '%s\n' "$fingerprints" | sed -n "s/^${key}=//p")
+	[[ "$value" =~ ^[0-9a-f]{64}$ ]]
+done
+
+[[ "$(git -C "$bundle_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$bundle_root" rev-parse HEAD)" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" rev-parse --verify "${bundle_sha}^{commit}")" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" symbolic-ref -q HEAD || true)" == '' ]]
+[[ "$(git -C "$bundle_root" status --porcelain=v1 --untracked-files=all --ignored=matching)" == '' ]]
+
+staging_parent=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+staging_root=$(mktemp -d "$staging_parent/tccbin-payload.XXXXXX")
+cleanup_paths=("$staging_root")
+linked_bundle=false
+for generated_v in v1 v2 v v1.exe v2.exe v.exe; do
+	[[ ! -e "$contract_root/$generated_v" && ! -L "$contract_root/$generated_v" ]]
+done
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+	if [[ "$linked_bundle" == true ]]; then
+		rm -rf -- "$contract_root/thirdparty/tcc"
+	fi
+	rm -f -- "$contract_root/v1" "$contract_root/v2" "$contract_root/v" \
+		"$contract_root/v1.exe" "$contract_root/v2.exe" "$contract_root/v.exe"
+	for cleanup_path in "${cleanup_paths[@]}"; do
+		[[ -n "$cleanup_path" && -d "$cleanup_path" ]] && rm -rf -- "$cleanup_path"
+	done
+	exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+git -C "$bundle_root" archive --format=tar "$bundle_sha" | tar -xf - -C "$staging_root"
+rm -rf -- "$staging_root/.github" "$staging_root/automation"
+case "$target_id" in
+	windows-amd64)
+		rm -f -- \
+			"$staging_root/build.ps1" \
+			"$staging_root/0001-tccpe-strip-quotes-and-default-.dll-extension-in-DEF.patch" \
+			"$staging_root/0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch" \
+			"$staging_root/0003-win32-declare-CreateSymbolicLink.patch" \
+			"$staging_root/0004-win32-declare-WSAConnectBy-family.patch" \
+			"$staging_root/0005-win32-declare-InetNtop-InetPton-family.patch" \
+			"$staging_root/0006-win32-declare-shell-drag-drop-family.patch" \
+			"$staging_root/0007-win32-declare-secure-narrow-stdio.patch" \
+			"$staging_root/0008-win32-fix-exp2-range-reduction.patch" \
+			"$staging_root/0009-win32-declare-CancelIoEx.patch" \
+			"$staging_root/vlang-header-compat.patch" \
+			"$staging_root/v-ae88ee5-tinycc-bdwgc.patch"
+		;;
+	linux-amd64 | macos-amd64 | macos-arm64 | freebsd-amd64 | openbsd-amd64)
+		rm -f -- "$staging_root/build.sh"
+		;;
+	*) printf '%s\n' 'unknown target for payload staging' >&2; exit 1 ;;
+esac
+
+staged_result=$(validator_command staged-preflight \
+	"$manifest" "$staging_root" "$bundle_root" "$bundle_sha" false)
+readonly expected_staged_result='eligible=false reason=staged_provenance_incomplete publish_allowed=false manifest_hash= input_fingerprint= artifact_fingerprint='
+[[ "$staged_result" == "$expected_staged_result" ]] || {
+	printf 'unexpected staged preflight result: %s\n' "$staged_result" >&2
+	exit 1
+}
+
+[[ "$(git -C "$contract_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$vc_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$contract_root" rev-parse HEAD)" == "$expected_contract_sha" ]]
+vc_sha=$(sed -n 's/^commit=//p' "$contract_root/thirdparty/tccbin_automation/bootstrap/vc.lock")
+[[ "$vc_sha" =~ ^[0-9a-f]{40}$ && "$(git -C "$vc_root" rev-parse HEAD)" == "$vc_sha" ]]
+
+contract_tcc="$contract_root/thirdparty/tcc"
+if [[ -e "$contract_tcc" || -L "$contract_tcc" ]]; then
+	[[ "$(cd -P -- "$contract_tcc" && pwd)" == "$(cd -P -- "$bundle_root" && pwd)" ]]
+else
+	ln -s "$bundle_root" "$contract_tcc"
+	linked_bundle=true
+fi
+
+case "$target_id" in
+	windows-amd64)
+		cc_name=${CC:-gcc}
+		exe_suffix=.exe
+		;;
+	*)
+		cc_name=${CC:-cc}
+		exe_suffix=
+		;;
+esac
+cc_path=$(command -v -- "$cc_name")
+[[ "$cc_path" == /* && -x "$cc_path" ]]
+
+if [[ "$target_id" == windows-amd64 ]]; then
+	"$cc_path" -std=c99 -municode -w -o "$contract_root/v1.exe" "$vc_root/v_win.c" \
+		-ladvapi32 -lws2_32 -Wl,-stack=33554432
+	(
+		cd -P -- "$contract_root"
+		./v1.exe -no-parallel -nocache -cc "$cc_path" -o ./v2.exe -gc none cmd/v
+		./v2.exe -no-parallel -nocache -cc "$cc_path" -o ./v.exe -gc none cmd/v
+	)
+else
+	link_flags=(-lm -lpthread)
+	v_link_flags=()
+	case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			link_flags+=(-lexecinfo)
+			v_link_flags=(-ldflags -lexecinfo)
+			;;
+	esac
+	"$cc_path" -std=c99 -w -o "$contract_root/v1" "$vc_root/v.c" "${link_flags[@]}"
+	(
+		cd -P -- "$contract_root"
+		./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none \
+			"${v_link_flags[@]}" cmd/v
+		./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none \
+			"${v_link_flags[@]}" cmd/v
+	)
+fi
+
+smoke_root=$(mktemp -d "$staging_parent/tccbin-v-smoke.XXXXXX")
+cleanup_paths+=("$smoke_root")
+cat > "$smoke_root/main.v" <<'VEOF'
+module main
+
+fn main() {
+	println('tccbin-v-smoke')
+}
+VEOF
+smoke_binary="$smoke_root/tccbin-v-smoke${exe_suffix}"
+if ! showcc_output=$(
+	cd -P -- "$contract_root"
+	"./v${exe_suffix}" -cc tcc -gc none -showcc -no-retry-compilation -no-rsp \
+		-o "$smoke_binary" "$smoke_root/main.v" 2>&1
+); then
+	printf '%s\n' "$showcc_output" >&2
+	exit 1
+fi
+printf '%s\n' "$showcc_output"
+if printf '%s\n' "$showcc_output" | grep -Eiq \
+	'falling back to|retrying with|fallback compiler|backup compiler'; then
+	printf '%s\n' 'V attempted a compiler fallback' >&2
+	exit 1
+fi
+normalized_showcc=$(printf '%s\n' "$showcc_output" | tr '\\' '/')
+case "$normalized_showcc" in
+	*'/thirdparty/tcc/tcc.exe'*) ;;
+	*) printf '%s\n' 'V did not report the bundled tcc.exe command' >&2; exit 1 ;;
+esac
+[[ -f "$smoke_binary" ]]
+[[ "$($smoke_binary)" == 'tccbin-v-smoke' ]]
+
+printf 'tccbin baseline contract target=%s staged=incomplete smoke=v-tcc publish=false: PASS\n' "$target_id"


### PR DESCRIPTION
## Summary

This PR adds the Phase A read-only automation baseline for the OpenBSD AMD64 tccbin bundle and binds it to the merged `vlang/v` automation contract.

It adds an immutable bundle manifest, contract and provenance validation, a no-fallback V smoke test, and the existing shared conformance checks behind a single branch gate.

## Why

The goal is to make future tccbin updates reproducible and auditable, while rejecting stale, incomplete, or unverified candidates before they can reach a publication path.

## Safety

This PR does not enable publication. Provenance remains incomplete, `PUBLISH` and `TCCBIN_PUBLISH` stay disabled, and the workflow has no secrets, artifact uploads, or Git push capability.