### PR TITLE
ci: add macos-amd64 tccbin automation baseline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,11 +5,29 @@ on:
     branches: [thirdparty-macos-amd64]
   pull_request:
     branches: [thirdparty-macos-amd64]
-  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+env:
+  CONTRACT_REPOSITORY: vlang/v
+  CONTRACT_SHA: 7545e515b434cd399333d43659238427d72e22e7
+  VC_SHA: dfc458a13ba8923ebc249e262c331f8169aa728b
+  PUBLISH: 'false'
+  TCCBIN_PUBLISH: 'false'
 
 jobs:
   build:
+    if: >-
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-macos-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-macos-amd64')
+      )
     runs-on: macos-15-intel
+    timeout-minutes: 90
     steps:
       # thirdparty/tccbin_tests (the shared cross-platform conformance
       # suite - see its README), thirdparty/libgc/include (gc.h), and
@@ -20,28 +38,62 @@ jobs:
       # script checks for, to confirm it's being run from a real v repo
       # checkout.
       - name: checkout v (for thirdparty/libgc, tccbin_tests, and the build script)
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           repository: vlang/v
-          ref: c82d3f08271e9324d6fb8de3c251e9c0e1a9154b
-          sparse-checkout: |
-            thirdparty/libgc
-            thirdparty/tccbin_tests
-            thirdparty/build_scripts
-            vlib/v/compiler_errors_test.v
-          sparse-checkout-cone-mode: false
+          ref: ${{ env.CONTRACT_SHA }}
           path: work
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: checkout immutable VC bootstrap snapshot
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          repository: vlang/vc
+          ref: ${{ env.VC_SHA }}
+          path: .tccbin-bootstrap-vc
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: bootstrap contract-bound validator
+        shell: bash
+        run: |
+          set -euo pipefail
+          validator_work="$RUNNER_TEMP/tccbin-validator-work"
+          test ! -e "$validator_work"
+          git -C work config --local core.autocrlf false
+          git -C .tccbin-bootstrap-vc config --local core.autocrlf false
+          work/thirdparty/tccbin_automation/bootstrap/bootstrap.sh \
+            "$GITHUB_WORKSPACE/work" "$CONTRACT_REPOSITORY" "$CONTRACT_SHA" \
+            "$GITHUB_WORKSPACE/.tccbin-bootstrap-vc" "$validator_work"
+          {
+            echo "TCCBIN_VALIDATOR_CLI=$validator_work/tccbin-automation"
+            echo "TCCBIN_VALIDATOR_CONTRACT_ROOT=$validator_work/contract-source"
+          } >> "$GITHUB_ENV"
 
       # this branch, checked out where the build script expects to find
       # itself (work/thirdparty/tcc), matching a normal local checkout
       # layout.
       - name: checkout this branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          ref: ${{ github.sha }}
           path: work/thirdparty/tcc
+          fetch-depth: 0
+          persist-credentials: false
 
-      # Codex pullrequestreview-4780178390 on vlang/tccbin#74 (P1): the
-      # steps below replace this branch's checked-in tcc.exe with a
+      - name: validate baseline manifest and immutable contract binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          git -C work/thirdparty/tcc config --local core.autocrlf false
+          bash work/thirdparty/tcc/automation/probes/baseline-contract.sh \
+            "$TCCBIN_VALIDATOR_CLI" "$TCCBIN_VALIDATOR_CONTRACT_ROOT" \
+            "$GITHUB_WORKSPACE/work/thirdparty/tcc" macos-amd64 \
+            thirdparty-macos-amd64 "$CONTRACT_SHA" "$GITHUB_SHA" \
+            "$GITHUB_WORKSPACE/.tccbin-bootstrap-vc"
+
+      # The steps below replace this branch's checked-in tcc.exe with a
       # rebuild from tinycc `mob`, and later replace libgc.a with a
       # rebuild from bdwgc `master`, before ever testing either - so a
       # future PR that commits a broken tcc.exe/libgc.a pair here would
@@ -71,8 +123,7 @@ jobs:
           # (non-executable) file mode would still pass a check that
           # silently repaired it first - but a real consumer checking out
           # this exact commit gets the actual committed mode, not this CI
-          # job's repaired one (Codex pullrequestreview-4783470598 on
-          # vlang/tccbin#74). Assert the committed mode is already correct
+          # job's repaired one. Assert the committed mode is already correct
           # instead of silently fixing it.
           if [ ! -x thirdparty/tcc/tcc.exe ]; then
             echo "::error::thirdparty/tcc/tcc.exe is not committed as executable - a consumer checking out this exact commit would get a non-executable file. This is a real regression in what this PR proposes to commit, not something CI should silently repair before testing."
@@ -157,7 +208,7 @@ jobs:
           # of a large archive's symbol list - under GitHub's bash
           # (pipefail enabled), that SIGPIPE-killed `nm` makes the WHOLE
           # pipeline report failure even though grep itself found the
-          # match (Codex pullrequestreview-4783470598 on vlang/tccbin#74).
+          # match.
           # Capture the full output first and grep the captured text
           # without -q.
           checkedin_gc_symbols=$(nm -g /tmp/checkedin_libgc_x86_64.a 2>&1) || true
@@ -243,14 +294,15 @@ jobs:
           if [ "$code" -eq 0 ]; then
             echo "::error::Static libgc.a linking now succeeds against the checked-in pair on macOS amd64 - this XFAIL special-casing should be removed and folded back into a single blocking lane, it's no longer needed."
             exit 1
+          elif [ "$code" -ne 1 ]; then
+            echo "::error::Static libgc.a checked-in XFAIL returned exit $code; expected TCC compile-error exit 1 exactly."
+            exit 1
           fi
 
-          # The pinned run.sh (c82d3f0..., predates vlang/v#27935's
-          # stderr-capture fix) only ever prints "(compile error)" with no
-          # detail - compile both failing tests directly to capture their
-          # real tcc stderr and assert each is specifically the known
-          # unresolved-GC-symbol error, the same reasoning already applied
-          # to the freshly-rebuilt archive's XFAIL lane below.
+          # The contract-pinned run.sh includes compiler stderr inline in
+          # its summary. Compile both failing tests directly as well so
+          # each exit status and error stream is isolated and can be
+          # checked for only the known unresolved-GC-symbol signature.
           set +e
           direct_err_gc_alloc=$(./thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/gc_alloc.c \
               -DGC_BUILTIN_ATOMIC=1 -DMPROTECT_VDB=1 \
@@ -270,23 +322,29 @@ jobs:
 
           is_known_gc_init() {
             # $1 = captured stderr text, $2 = the probe's own exit code.
-            # Same reasoning as the freshly-rebuilt archive's equivalent
-            # check below: reject a signal-terminated exit (128+signal)
-            # and reject exit 0 (a changed tcc.exe could print this same
-            # diagnostic as noise while still reporting overall success).
-            if [ "$2" -eq 0 ] || [ "$2" -gt 128 ]; then
+            # TCC's compile-error exit is exactly 1. Every nonempty stderr
+            # line must be one complete unresolved GC_* diagnostic; require
+            # GC_init specifically so an unrelated missing symbol cannot
+            # masquerade as the known archive-parsing limitation.
+            if [ "$2" -ne 1 ]; then
               return 1
             fi
-            case "$1" in
-              *"unresolved reference to '_GC_init'"*|*"unresolved reference to 'GC_init'"*) ;;
-              *) return 1 ;;
-            esac
-            other=$(printf '%s\n' "$1" | grep -E '^tcc: error:' | grep -v -E "unresolved reference to '_?GC_[A-Za-z0-9_]+'")
-            [ -z "$other" ]
+            stderr_lines=$(printf '%s\n' "$1" | sed '/^$/d')
+            [ -n "$stderr_lines" ] || return 1
+            unexpected=$(printf '%s\n' "$stderr_lines" | grep -Ev "^tcc: error: unresolved reference to '_?GC_[A-Za-z0-9_]+'$" || true)
+            [ -z "$unexpected" ] || return 1
+            printf '%s\n' "$stderr_lines" | grep -E "^tcc: error: unresolved reference to '_?GC_init'$" >/dev/null
           }
 
+          pass_count=$(printf '%s\n' "$output" | grep -Ec '^PASS ' || true)
+          fail_count=$(printf '%s\n' "$output" | grep -Ec '^FAIL ' || true)
+          final_summary=$(printf '%s\n' "$output" | sed '/^$/d' | tail -n 1)
           case "$output" in
-            *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
+            *"PASS crash"*"FAIL gc_alloc (compile error:"*"FAIL hello (compile error:"*)
+              if [ "$pass_count" -ne 1 ] || [ "$fail_count" -ne 2 ] || [ "$final_summary" != '1 passed, 2 failed' ]; then
+                echo "::error::Static libgc.a summary counts/final line differ from the exact known XFAIL (PASS=1, FAIL=2, final='1 passed, 2 failed')."
+                exit 1
+              fi
               if is_known_gc_init "$direct_err_gc_alloc" "$direct_code_gc_alloc" && is_known_gc_init "$direct_err_hello" "$direct_code_hello"; then
                 echo "known XFAIL: static libgc.a still can't link gc_alloc.c/hello.c against the checked-in pair (unresolved GC_init, the known tcc archive-parsing bug), as expected - not blocking CI"
               else
@@ -308,14 +366,6 @@ jobs:
         # by the tcc build itself.
         run: brew install make automake libtool
 
-      - name: configure git identity
-        # the build script commits the rebuilt binaries inside
-        # $TCC_FOLDER as its last step; it needs an identity to do
-        # that even though we never push this commit anywhere.
-        run: |
-          git config --global user.name tccbin-ci
-          git config --global user.email tccbin-ci@users.noreply.github.com
-
       # This branch's tcc.exe is stale (version 0.9.27, no
       # build_source_hash.txt/build_version.txt provenance tracking at
       # all - unlike every other actively-maintained platform branch),
@@ -327,15 +377,13 @@ jobs:
       # such file or directory" on this macos-15-intel runner). No CI
       # flag can fix a broken symlink baked into the committed binary -
       # rebuilding from current tinycc (mob) with the official script
-      # is the actual fix, reusing this branch's already-committed
-      # libgc.a (the script's own rsync step preserves it, no GC
-      # rebuild needed).
+      # is the actual fix. The managed-bundle mode produces a detached
+      # stage; the following step then rebuilds libgc for that stage.
       # MACOSX_DEPLOYMENT_TARGET pinned to 10.13 (High Sierra, 2017) -
       # without it, clang stamps rebuilt binaries with this CI runner's
-      # own macOS 15 minimum, so the uploaded generic macOS-amd64
+      # own macOS 15 minimum, so the generic macOS-amd64
       # distribution silently couldn't run on older Intel macOS releases
-      # the existing prebuilt distribution supports (Codex
-      # pullrequestreview-4780918023 on vlang/tccbin#74). 10.13 is a
+      # the existing prebuilt distribution supports. 10.13 is a
       # conservative, widely-used baseline for Intel-only distributions;
       # the "verify the checked-in tcc.exe" step above now also surfaces
       # the CURRENT binary's actual load-command minimum via otool, to
@@ -345,22 +393,24 @@ jobs:
         env:
           TCC_COMMIT: mob
           TCC_FOLDER: thirdparty/tcc
+          TCCBIN_DEFER_COMMIT: '1'
+          TCCBIN_STAGE_ROOT: ${{ runner.temp }}/tccbin-macos-amd64-stage
           CC: clang
           MACOSX_DEPLOYMENT_TARGET: "10.13"
         run: |
           set -eu
-          # The official script's own carry-forward step
-          # (`rsync -a thirdparty/tcc.original/lib/build*  $TCC_FOLDER/lib/`)
-          # expects prior lib/build_*.txt provenance files to exist -
-          # true for every other platform, since they've already been
-          # through this pipeline at least once. This branch never has
-          # (confirmed: no build_source_hash.txt/build_version.txt at
-          # all before this), so the glob matches nothing and rsync
-          # errors "No such file or directory" on its first-ever run
-          # through the modern pipeline. Seed one placeholder so the
-          # glob has something to match; the script overwrites the real
-          # build_*.txt files with accurate content right after anyway.
-          touch thirdparty/tcc/lib/build_bootstrap_marker.txt
+          candidate_root="$PWD/thirdparty/tcc"
+          committed_root="$PWD/thirdparty/tcc.committed"
+          test ! -L "$candidate_root"
+          test -d "$candidate_root"
+          test "$(cd "$candidate_root" && pwd -P)" = "$candidate_root"
+          test ! -e "$committed_root"
+          test ! -L "$committed_root"
+          test ! -e "$TCCBIN_STAGE_ROOT"
+          test ! -L "$TCCBIN_STAGE_ROOT"
+          test "$(git -C "$candidate_root" rev-parse HEAD)" = "$GITHUB_SHA"
+          candidate_status=$(git -C "$candidate_root" status --porcelain=v1 --untracked-files=all --ignored=matching)
+          test -z "$candidate_status"
 
           # repo.or.cz's HTTPS endpoint has been observed to fail
           # intermittently in CI (confirmed independently, including from
@@ -369,12 +419,9 @@ jobs:
           # HTTPS failed - but that fallback is itself the vulnerability:
           # an active on-path attacker can simply block HTTPS to FORCE
           # the fallback, then feed tampered tinycc source into a
-          # compile-and-run pipeline whose output gets uploaded as a
-          # build artifact. A warning in the log doesn't mitigate that -
-          # the tampered source still gets built and run either way
-          # (Codex pullrequestreview-4780817355 on vlang/tccbin#74,
-          # tightening pullrequestreview-4780178390's earlier retry-then-
-          # fall-back mitigation). No downgrade path exists anymore - if
+          # compiler-and-test pipeline. A warning in the log doesn't
+          # mitigate that - the tampered source still gets built and run.
+          # No downgrade path exists anymore - if
           # HTTPS is genuinely unreachable, the job fails for real.
           #
           # A lightweight `git ls-remote` probe succeeding beforehand
@@ -389,11 +436,10 @@ jobs:
           # when its failure specifically matches a network-connection
           # signature, so a genuine build bug (a real gmake failure, a
           # configure error) fails fast instead of wasting 3 attempts on
-          # something retrying will never fix. The script itself does
-          # `rm -rf tinycc/` unconditionally as its first action, and
-          # the network operation (git clone) happens before any step
-          # that mutates $TCC_FOLDER, so retrying the whole script after
-          # a network failure is safe - no partial state to clean up.
+          # something retrying will never fix. In deferred mode the
+          # script builds only in isolated temporary roots, and its trap
+          # removes incomplete work/output before it returns failure;
+          # the authenticated checkout is never mutated by a retry.
           attempt=0
           while true; do
             attempt=$((attempt + 1))
@@ -420,6 +466,30 @@ jobs:
                 ;;
             esac
           done
+
+          # Keep the authenticated checkout intact for restoration and
+          # promote only the detached output produced by deferred mode.
+          # Every following build/test step addresses thirdparty/tcc and
+          # therefore sees the promoted stage, never a mixed overlay.
+          test ! -L "$TCCBIN_STAGE_ROOT"
+          test -d "$TCCBIN_STAGE_ROOT"
+          test "$(cd "$TCCBIN_STAGE_ROOT" && pwd -P)" = "$TCCBIN_STAGE_ROOT"
+          test -f "$TCCBIN_STAGE_ROOT/tcc.exe"
+          test ! -L "$TCCBIN_STAGE_ROOT/tcc.exe"
+          test -x "$TCCBIN_STAGE_ROOT/tcc.exe"
+          test ! -e "$TCCBIN_STAGE_ROOT/.git"
+          test ! -L "$TCCBIN_STAGE_ROOT/.git"
+          test ! -e "$TCCBIN_STAGE_ROOT/automation"
+          test ! -L "$TCCBIN_STAGE_ROOT/automation"
+          mv "$candidate_root" "$committed_root"
+          mv "$TCCBIN_STAGE_ROOT" "$candidate_root"
+          test ! -L "$candidate_root"
+          test -d "$candidate_root"
+          test "$(cd "$candidate_root" && pwd -P)" = "$candidate_root"
+          test "$(git -C "$committed_root" rev-parse HEAD)" = "$GITHUB_SHA"
+          committed_status=$(git -C "$committed_root" status --porcelain=v1 --untracked-files=all --ignored=matching)
+          test -z "$committed_status"
+
           thirdparty/tcc/tcc.exe --version
           thirdparty/tcc/tcc.exe -v -v
 
@@ -453,9 +523,8 @@ jobs:
           CC: clang
           TCC_FOLDER: thirdparty/tcc
           LIBGC_COMMIT: master
-          # See the "build tcc.exe" step's comment - same deployment-
-          # target gap Codex flagged applies to this build too (Codex
-          # pullrequestreview-4780918023 on vlang/tccbin#74).
+          # See the "build tcc.exe" step's comment - the same deployment-
+          # target requirement applies to this build too.
           MACOSX_DEPLOYMENT_TARGET: "10.13"
         run: |
           set -eu
@@ -469,8 +538,7 @@ jobs:
           # below previously recorded only bdwgc's own commit - two
           # artifacts could carry an identical libgc_build_source_hash.txt
           # while containing different libatomic_ops code, making the
-          # archive untraceable (Codex pullrequestreview-4780918023 on
-          # vlang/tccbin#74). Record its resolved commit too.
+          # archive untraceable. Record its resolved commit too.
           git clone --quiet https://github.com/bdwgc/libatomic_ops
           LIBATOMIC_OPS_COMMIT_FULL_HASH="$(git -C libatomic_ops rev-parse HEAD)"
           ./autogen.sh
@@ -501,14 +569,12 @@ jobs:
           # archive's build (a universal x86_64/arm64 configure
           # invocation) - if left untouched it would keep claiming that
           # for the archive THIS step just produced with a materially
-          # different, amd64-only configure line, making every uploaded
-          # artifact's provenance false (Codex pullrequestreview-
-          # 4780817355 on vlang/tccbin#74). Overwrite it with the actual
+          # different, amd64-only configure line, making the rebuilt
+          # bundle's provenance false. Overwrite it with the actual
           # command used above - including MACOSX_DEPLOYMENT_TARGET,
           # which materially affects dylib/archive compatibility and
           # would otherwise be missing from anyone trying to reproduce
-          # this exact build from the recorded command (Codex
-          # pullrequestreview-4781470066 on vlang/tccbin#74).
+          # this exact build from the recorded command.
           echo "MACOSX_DEPLOYMENT_TARGET=\"$MACOSX_DEPLOYMENT_TARGET\" CC=\"$CC\" CFLAGS=\"-Os -mtune=generic -fPIC\" LDFLAGS=\"-Os -fPIC\" ./configure --disable-dependency-tracking --disable-docs --enable-static=yes --enable-shared=yes --enable-single-obj-compilation --enable-gc-debug --enable-thread-local-alloc --enable-large-config --enable-cplusplus --with-libatomic-ops=check --enable-sigrt-signals" \
               > "$TCC_FOLDER/lib/libgc_build_cmd.txt"
           rsync -a bdwgc/.libs/ "$TCC_FOLDER/lib/"
@@ -568,8 +634,7 @@ jobs:
           # Any nonzero exit isn't enough: if the executable can't even
           # start (missing loader, an unresolved dynamic library) the
           # shell also reports a nonzero status, which this check would
-          # wrongly accept as "the expected crash" (Codex
-          # pullrequestreview-4780817355 on vlang/tccbin#74). crash.c's
+          # wrongly accept as "the expected crash". crash.c's
           # null-pointer dereference is expected to be killed by SIGSEGV
           # specifically, which a POSIX shell reports as exit code
           # 128+11=139 - verify that exact signal-terminated signature.
@@ -583,9 +648,7 @@ jobs:
           # broken libtcc1.a/crt or startup path made EVERY program
           # segfault immediately (before ever reaching the intentional
           # null-pointer dereference), this check would still see exit
-          # 139 and wrongly call it "expected" (Codex pullrequestreview-
-          # 4781468264 on the sibling freebsd-amd64 workflow, vlang/
-          # tccbin#75, same class of gap here). The GC-backed lanes
+          # 139 and wrongly call it "expected". The GC-backed lanes
           # can't provide this positive check either, since the static
           # one is expected to fail at link time. Compile and run a
           # trivial, non-crashing program with the same no-GC flags,
@@ -628,8 +691,7 @@ jobs:
           # exact same shape as tcc's own known archive-parsing
           # limitation - and KNOWN_ISSUES.txt would claim the symbol is
           # "present and well-formed" even though nothing here ever
-          # checked that (Codex pullrequestreview-4783389496 on vlang/
-          # tccbin#74). Validate the rebuilt archive directly via ar/nm
+          # checked that. Validate the rebuilt archive directly via ar/nm
           # before treating any link failure against it as the known,
           # harmless tcc limitation.
           if ! ar t ./thirdparty/tcc/lib/libgc.a >/dev/null 2>&1; then
@@ -642,10 +704,8 @@ jobs:
           # (pipefail enabled), that SIGPIPE-killed `nm` makes the WHOLE
           # pipeline report failure even though grep itself found the
           # match, so this reported "does not define GC_init" on every
-          # run regardless of the archive's actual contents (Codex
-          # pullrequestreview-4783470598 on vlang/tccbin#74 - the exact
-          # bug that broke run 30234854073, the CI run right after this
-          # check was first added). Capture the full output first
+          # run regardless of the archive's actual contents. Capture the
+          # full output first
           # (command substitution fully drains the producer, no early
           # exit possible) and grep the captured text without -q.
           rebuilt_gc_symbols=$(nm -g ./thirdparty/tcc/lib/libgc.a 2>&1) || true
@@ -668,22 +728,19 @@ jobs:
           if [ "$code" -eq 0 ]; then
             echo "::error::Static libgc.a linking now succeeds on macOS amd64 - this lane's special-casing should be removed and folded back into a single blocking lane, this workaround is no longer needed."
             exit 1
+          elif [ "$code" -ne 1 ]; then
+            echo "::error::Static libgc.a rebuilt XFAIL returned exit $code; expected TCC compile-error exit 1 exactly."
+            exit 1
           fi
 
-          # The pinned run.sh (c82d3f0..., predates vlang/v#27935's
-          # stderr-capture fix) only ever prints "(compile error)" with no
-          # detail, so the summary-line match above can't tell "the known
-          # GC_init archive-parsing bug" apart from a DIFFERENT static-link
-          # regression that happens to fail the same two tests (a
-          # corrupted/wrong-architecture archive, an unrelated compiler
-          # bug) - Codex pullrequestreview-4780178390 on vlang/tccbin#74.
-          # Compile BOTH failing tests directly to capture their real tcc
-          # stderr and assert each is specifically the known unresolved-
+          # The contract-pinned run.sh includes compiler stderr inline in
+          # its summary, but that aggregate output does not preserve each
+          # compile's exit status independently. Compile BOTH failing tests
+          # directly and assert each is specifically the known unresolved-
           # GC-symbol error - checking only one of the two (e.g.
           # gc_alloc.c) would let an unrelated regression isolated to the
           # OTHER test (hello.c) hide behind this same summary shape and
-          # pass unnoticed (same class of gap as Codex pullrequestreview-
-          # 4780815399 on the sibling freebsd-amd64 workflow, vlang/tccbin#75).
+          # pass unnoticed.
           set +e
           direct_err_gc_alloc=$(./thirdparty/tcc/tcc.exe thirdparty/tccbin_tests/shared/gc_alloc.c \
               -DGC_BUILTIN_ATOMIC=1 -DMPROTECT_VDB=1 \
@@ -707,53 +764,35 @@ jobs:
           # _GC_noop1; hello.c: _GC_init, _GC_noop1) - checking for one
           # exact symbol name alone isn't enough to also catch a
           # DIFFERENT regression that adds a non-GC unresolved symbol
-          # alongside the known ones (Codex pullrequestreview-4780907186
-          # on the sibling freebsd-amd64 workflow, vlang/tccbin#75, same
-          # class of gap). Require GC_init specifically to confirm the
+          # alongside the known ones. Require GC_init specifically to confirm the
           # known root cause, AND reject if any unresolved-reference line
           # does NOT match the GC_-prefixed pattern the archive-parsing
           # bug produces.
           is_known_gc_init() {
             # $1 = captured stderr text, $2 = the probe's own exit code.
-            # A regression could make tcc print the expected GC_init
-            # diagnostic and then crash/abort rather than exiting
-            # cleanly with its normal compile-error status - the earlier
-            # `|| true` discarded that exit code entirely (Codex
-            # pullrequestreview-4781865117 on the sibling freebsd-amd64
-            # workflow, vlang/tccbin#75, same class of gap here). A
-            # POSIX shell reports a signal-terminated process as exit
-            # code 128+signal; reject those instead of treating any
-            # nonzero exit as "the expected compile-error status". Also
-            # reject exit 0: a changed tcc.exe could start printing this
-            # same diagnostic as noise while still reporting overall
-            # success - the text alone isn't proof the compile actually
-            # failed (Codex pullrequestreview-4783389496 on vlang/
-            # tccbin#74).
-            if [ "$2" -eq 0 ] || [ "$2" -gt 128 ]; then
+            # TCC's compile-error exit is exactly 1. Every nonempty stderr
+            # line must be one complete unresolved GC_* diagnostic; require
+            # GC_init specifically so an unrelated missing symbol cannot
+            # masquerade as the known archive-parsing limitation.
+            if [ "$2" -ne 1 ]; then
               return 1
             fi
-            case "$1" in
-              *"unresolved reference to '_GC_init'"*|*"unresolved reference to 'GC_init'"*) ;;
-              *) return 1 ;;
-            esac
-            # Filtering only "unresolved reference to '...'" lines and
-            # checking their NAMES misses a wholly DIFFERENT kind of tcc
-            # error (invalid object, relocation error, etc.) riding
-            # alongside the known one - such a line simply wouldn't match
-            # the "unresolved reference to" pattern at extraction, so
-            # `other` would stay empty and this would wrongly accept the
-            # XFAIL (Codex pullrequestreview-4781468264 on the sibling
-            # freebsd-amd64 workflow, vlang/tccbin#75, same class of gap
-            # here). Match on tcc's actual error-line prefix instead, so
-            # ANY tcc error line that isn't specifically a GC_-prefixed
-            # unresolved reference gets caught, not just a differently-
-            # named one.
-            other=$(printf '%s\n' "$1" | grep -E '^tcc: error:' | grep -v -E "unresolved reference to '_?GC_[A-Za-z0-9_]+'")
-            [ -z "$other" ]
+            stderr_lines=$(printf '%s\n' "$1" | sed '/^$/d')
+            [ -n "$stderr_lines" ] || return 1
+            unexpected=$(printf '%s\n' "$stderr_lines" | grep -Ev "^tcc: error: unresolved reference to '_?GC_[A-Za-z0-9_]+'$" || true)
+            [ -z "$unexpected" ] || return 1
+            printf '%s\n' "$stderr_lines" | grep -E "^tcc: error: unresolved reference to '_?GC_init'$" >/dev/null
           }
 
+          pass_count=$(printf '%s\n' "$output" | grep -Ec '^PASS ' || true)
+          fail_count=$(printf '%s\n' "$output" | grep -Ec '^FAIL ' || true)
+          final_summary=$(printf '%s\n' "$output" | sed '/^$/d' | tail -n 1)
           case "$output" in
-            *"PASS crash"*"FAIL gc_alloc (compile error)"*"FAIL hello (compile error)"*)
+            *"PASS crash"*"FAIL gc_alloc (compile error:"*"FAIL hello (compile error:"*)
+              if [ "$pass_count" -ne 1 ] || [ "$fail_count" -ne 2 ] || [ "$final_summary" != '1 passed, 2 failed' ]; then
+                echo "::error::Static libgc.a summary counts/final line differ from the exact known XFAIL (PASS=1, FAIL=2, final='1 passed, 2 failed')."
+                exit 1
+              fi
               if is_known_gc_init "$direct_err_gc_alloc" "$direct_code_gc_alloc" && is_known_gc_init "$direct_err_hello" "$direct_code_hello"; then
                 echo "known XFAIL: static libgc.a still can't link gc_alloc.c/hello.c (unresolved GC_init, the known tcc archive-parsing bug), as expected - not blocking CI"
               else
@@ -769,69 +808,72 @@ jobs:
               ;;
           esac
 
-      # This artifact bundles thirdparty/tcc/lib/libgc.a even though the
-      # XFAIL lane above proves this tcc.exe can't link it - V's existing
-      # tinyc+boehm path for macOS amd64 still selects that static
-      # archive (vlib/builtin/builtin_d_gcboehm.c.v), so anyone who
-      # downloads and installs this as the distribution would hit
-      # working GC builds turning into silent link failures, despite the
-      # dynamic dylib lane passing (Codex pullrequestreview-4780918023
-      # on vlang/tccbin#74). Not pulling libgc.a out of the archive -
-      # some future consumer may still want it for reference/debugging,
-      # and V's builder isn't switched to the dylib yet (see this PR's
-      # earlier reply on that sequencing) - but a downloader must not be
-      # able to miss this caveat.
-      # `!cancelled()` stays true after an ORDINARY step failure (it only
-      # excludes a cancelled run), so a failure in the blocking dylib
-      # lane or the no-GC check still reached this step - publishing an
-      # artifact whose bundled KNOWN_ISSUES.txt unconditionally claimed
-      # "verified working in this build's own CI run" even when this
-      # run's own validation didn't pass (Codex pullrequestreview-
-      # 4781470066 on vlang/tccbin#74). Keep publishing on failure too -
-      # a maintainer debugging a red run still gets a downloadable build
-      # to reproduce against (mirroring macos-arm64's own rationale for
-      # `!cancelled()` here) - but make the claim match what THIS run
-      # actually verified, using the two prior steps' real outcomes.
-      # The static-link claim below (that libgc.a can't be linked by
-      # this tcc.exe) was, until now, ALSO printed unconditionally - if
-      # the static XFAIL step above failed with an unexpected signature,
-      # or unexpectedly passed, this artifact would still assert the
-      # known archive-parsing diagnosis as if this run had confirmed it
-      # (Codex pullrequestreview-4782525602 on vlang/tccbin#74, same
-      # class of gap as the dylib/no-GC claims fixed just below it).
-      - name: package rebuilt tcc for upload
-        if: ${{ !cancelled() }}
+      - name: restore committed tcc checkout for post-job cleanup
+        if: ${{ always() }}
         working-directory: work
         env:
-          DYLIB_TEST_OUTCOME: ${{ steps.dylib_test.outcome }}
-          NOGC_TEST_OUTCOME: ${{ steps.nogc_test.outcome }}
-          STATIC_XFAIL_TEST_OUTCOME: ${{ steps.static_xfail_test.outcome }}
+          TCCBIN_STAGE_ROOT: ${{ runner.temp }}/tccbin-macos-amd64-stage
         run: |
-          if [ "$STATIC_XFAIL_TEST_OUTCOME" = "success" ]; then
-            static_claim="lib/libgc.a (static archive) CANNOT be linked by this tcc.exe - confirmed via a real CI run: tcc reports \"unresolved reference to '_GC_init'\" etc. even though the symbol is present and well-formed in the archive (a tcc Mach-O archive-parsing limitation, the same one already documented on macos-arm64)."
-          else
-            static_claim="THIS BUILD'S OWN CI VALIDATION OF THE STATIC libgc.a LINK FAILURE DID NOT CONFIRM THE EXPECTED SIGNATURE (static XFAIL test outcome: $STATIC_XFAIL_TEST_OUTCOME) - do not assume lib/libgc.a's link status from this specific artifact without checking the workflow run's log."
+          set -eu
+          candidate_root="$PWD/thirdparty/tcc"
+          committed_root="$PWD/thirdparty/tcc.committed"
+          rebuilt_discard="$RUNNER_TEMP/tccbin-macos-amd64-rebuilt"
+          unpromoted_discard="$RUNNER_TEMP/tccbin-macos-amd64-unpromoted"
+          if test -e "$TCCBIN_STAGE_ROOT" || test -L "$TCCBIN_STAGE_ROOT"; then
+            test ! -L "$TCCBIN_STAGE_ROOT"
+            test -d "$TCCBIN_STAGE_ROOT"
+            test "$(cd "$TCCBIN_STAGE_ROOT" && pwd -P)" = "$TCCBIN_STAGE_ROOT"
+            test ! -e "$unpromoted_discard"
+            test ! -L "$unpromoted_discard"
+            mv "$TCCBIN_STAGE_ROOT" "$unpromoted_discard"
           fi
-          if [ "$DYLIB_TEST_OUTCOME" = "success" ] && [ "$NOGC_TEST_OUTCOME" = "success" ]; then
-            dylib_claim="Use lib/libgc.dylib with -Wl,-rpath,<path-to-lib> instead; that link path is verified working in this build's own CI run."
-          else
-            dylib_claim="THIS BUILD'S OWN CI VALIDATION DID NOT PASS (dylib test: $DYLIB_TEST_OUTCOME, no-GC test: $NOGC_TEST_OUTCOME) - do not treat lib/libgc.dylib as a verified-working link path from this specific artifact. Check the workflow run's log before relying on it."
+          if test -e "$committed_root" || test -L "$committed_root"; then
+            test ! -L "$committed_root"
+            test -d "$committed_root"
+            test "$(cd "$committed_root" && pwd -P)" = "$committed_root"
+            test "$(git -C "$committed_root" rev-parse HEAD)" = "$GITHUB_SHA"
+            committed_status=$(git -C "$committed_root" status --porcelain=v1 --untracked-files=all --ignored=matching)
+            test -z "$committed_status"
+            if test -e "$candidate_root" || test -L "$candidate_root"; then
+              test ! -L "$candidate_root"
+              test -d "$candidate_root"
+              test "$(cd "$candidate_root" && pwd -P)" = "$candidate_root"
+              test ! -e "$candidate_root/.git"
+              test ! -L "$candidate_root/.git"
+              test ! -e "$rebuilt_discard"
+              test ! -L "$rebuilt_discard"
+              mv "$candidate_root" "$rebuilt_discard"
+            fi
+            mv "$committed_root" "$candidate_root"
           fi
-          cat > thirdparty/tcc/KNOWN_ISSUES.txt <<EOF
-          This is a CI-verification build, not a drop-in replacement for the
-          committed tccbin-macos-amd64 distribution.
+          test ! -L "$candidate_root"
+          test -d "$candidate_root"
+          test "$(cd "$candidate_root" && pwd -P)" = "$candidate_root"
+          test "$(git -C "$candidate_root" rev-parse HEAD)" = "$GITHUB_SHA"
+          candidate_status=$(git -C "$candidate_root" status --porcelain=v1 --untracked-files=all --ignored=matching)
+          test -z "$candidate_status"
+          test ! -e "$committed_root"
+          test ! -L "$committed_root"
+          test ! -e "$TCCBIN_STAGE_ROOT"
+          test ! -L "$TCCBIN_STAGE_ROOT"
 
-          $static_claim $dylib_claim
-
-          V's existing builtin_d_gcboehm.c.v for macOS amd64+tinyc still
-          selects the static libgc.a - do not switch it to the dylib until a
-          build like this one is committed to the actual distribution branch.
-          EOF
-          tar --exclude=.git -czf tccbin-macos-amd64-current.tar.gz thirdparty/tcc
-
-      - name: upload rebuilt binaries
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: tccbin-macos-amd64-current
-          path: work/tccbin-macos-amd64-current.tar.gz
+  tccbin-branch-gate:
+    name: tccbin-branch-gate
+    if: >-
+      always() &&
+      github.repository == 'vlang/tccbin' &&
+      (
+        (github.event_name == 'pull_request' &&
+          github.base_ref == 'thirdparty-macos-amd64') ||
+        (github.event_name == 'push' &&
+          github.ref == 'refs/heads/thirdparty-macos-amd64')
+      )
+    needs: [build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: require successful baseline validation
+        shell: bash
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: test "$BUILD_RESULT" = success

--- a/automation/bundle-manifest.json
+++ b/automation/bundle-manifest.json
@@ -1,0 +1,1052 @@
+{
+  "schema_version": 1,
+  "contract_version": 1,
+  "contract_repository": "vlang/v",
+  "contract_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "contract_mode": "production",
+  "v_source_sha": "7545e515b434cd399333d43659238427d72e22e7",
+  "target_id": "macos-amd64",
+  "branch": "thirdparty-macos-amd64",
+  "sources": [
+    {
+      "id": "tinycc",
+      "repository": "https://repo.or.cz/tinycc.git",
+      "ref": "mob",
+      "sha": null,
+      "tree": null
+    },
+    {
+      "id": "bdwgc",
+      "repository": "https://github.com/ivmai/bdwgc.git",
+      "ref": "master",
+      "sha": null,
+      "tree": null
+    },
+    {
+      "id": "libatomic_ops",
+      "repository": "https://github.com/bdwgc/libatomic_ops.git",
+      "ref": "master",
+      "sha": null,
+      "tree": null
+    }
+  ],
+  "recipe": {
+    "path": "build.sh",
+    "version": 1,
+    "sha256": "3564f238a107ef56a594fe5e9f1cd60fb5d81579f178d4de192043b57ebd0238"
+  },
+  "toolchain": {
+    "profile_id": null,
+    "profile_sha256": null,
+    "producer_observation": null
+  },
+  "patches": [],
+  "transforms": [],
+  "header_effects": [],
+  "integrations": [],
+  "overlays": [],
+  "inventory": [
+    {
+      "path": "README.md",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "9876d5cc7a54f6b1965cd0b4794886f6ce5b05c07e699ee2317def56cb19d62d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "50be4ef504994a0c49a2ab294cfa35d19c4f57569f10f8ee24727f3e16fbdaa6",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_macosx_deployment_target.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "35a8679786adf4cc7ad1a65a9a3f38fae99546cec9e2d5f0af380c19d5b73597",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c7fbc860ce2300b9cb25c05dff2f72cfe15e4e5969bcba88139df82efb85af67",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "8861787d61e7b801112e7ca64c4a90cc275797ef1d58bc3d1053f3fe81f98b0d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_toolchain_identity.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2837c5948b45916f519912ef23256ae973af42c72decd6185aec65f45b804d3f",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "build_version.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e3a635314132a0b001eae8fec68d9cf417a262b604cea273d3601ea11efce989",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "bundle_checksums.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "46ae1db98501ff724679eba6856c068f168df1565633a489d81d7b270391965f",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "include/libtcc.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "42e1fb86b44088850e0e17ec0947b483a2edb586b420d18196d7b9b5dce944e4",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/bcheck.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "1a9a057676bf85ede16951e08a7395583f6cf2bd9b28e847bc725db23ce373a8",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/bt-exe.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "cd21ee910256501baf69ad60b2aee1b7efcbe56bba30b2b063bf6b1b612df305",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/bt-log.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "447996361b21b0ec1c62e40b4f693873f25f5eb8aa17e6831da109f3cbb6960e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/float.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "484ffee95fcdbc00cdc154b9dc2fe03fed65610bf1a73b610871cc39698e6f8e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdalign.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "7612d46571099ccaa7616a510f78f180cb1e91671e6e5e9223a2e297b84b789d",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdarg.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a38f8d34f5e09658cc3a8892b3a7e80ff566eaeedc194e5a85ece0b675993137",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdatomic.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "4fbd9d6ec9add338d41c06f44115121925f087dd91f445b56cca1aacb84360e1",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdbool.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "5252824225ddc486b0460677f765e4157af5d3ed7acd65b310a4045eafb56af7",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stddef.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "c42eaa62f574527b8d0d64f802b20c27ebeb66feb2c3608e9b9659225ad6ed45",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/stdnoreturn.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ec64d8fbf7fb2e800df9784b2efca0a99fc25a3eb5e8da56e4df098937f787f2",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/tccdefs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d1016b6170c45f1b8e7f8d83bf1f00f21e288eb2e446d9f141457f6f821acf7b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/tcclib.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2cfbd6b9c5e039721fbfb8e6f95a0a9fc30597bbcb2aefa3dda572c278009429",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/tgmath.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "e60c66ff9017f13ab18ee38824792ca771b9235bcb4df57688fec582739524a5",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/include/varargs.h",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "07858857f4eed0a61df94beb1a9d678b53fc3d67a0b0e8936155f85ddbcd1dcc",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libc.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "e7bcb0d6952965edf7ac86d2e8e787b12f191ae1b284614ded3958a824ab5cab",
+      "symlink_target": "/System/DriverKit/usr/lib/libSystem.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.1.dylib",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "0340bc2ebd9684cc0c5e64414b9c8842822b1f2a0536041db1bc368d8dafd83e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "0c2cf329892ed832aab8acdfc70925500d40151558155d61386ae18d125d3b22",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "a585a7bbd2be5ca3e0878d1cd1421ef322692d9e31b0da70a92e34a7c9bf52a9",
+      "symlink_target": "libgc.1.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_cmd.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "ac090304c4f3cf604b44f43712f2a64dab008306c7b87b9702809d6ba3df8459",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_libatomic_ops_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "2fcda2caa8123ab4f362f38ff5a4932382b83bed92387c7e575893be4bfe5f19",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_machine_uname.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "50be4ef504994a0c49a2ab294cfa35d19c4f57569f10f8ee24727f3e16fbdaa6",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_on_date.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "326c99ee6ca6115b69ba6453d807fd7a0b721c5e389a0bd90c769ff69b406d2b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_recipe_version.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "53c234e5e8472b6ac51c1ae1cab3fe06fad053beb8ebfd8977b010655bfdd3c3",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgc_build_source_hash.txt",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "76c96d030359221578c620e5ea661010c1311752046176cf9a20296eb99e447f",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.1.dylib",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "4bc166df93c149179bbc07ff8c5c8cab58dfa7cba4ce7cda14feea388ba21174",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "33305e7af3e14eb9441dd55fac1774a4da7a1539aa1b9ae3ed717d72c71cd2eb",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgccpp.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "82754ba227ddfd52a128cdce9b353048d0cf5ec3ea7ceebeee01dbee21016da9",
+      "symlink_target": "libgccpp.1.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.1.dylib",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "e4e2f60e72536c27b677d9bd8c2e63d7c5c7fb23336570c19864d96c08c4daed",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "a33cf323093fdff54538dde1477c5a16828a3b3561f116b0d640bc70b2b24f9c",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libgctba.dylib",
+      "kind": "symlink",
+      "git_mode": "120000",
+      "sha256": "31e383001e01134ee678744fe9c4e5faafd58fef6f3629d6b20d306abc994dfa",
+      "symlink_target": "libgctba.1.dylib",
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "d770e8e3aad6cae50923e931ae4b06ed54ac1a0dd19317e755754b8e93e4f68b",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/libtcc1.a",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "fc46a21fc35eadbeb5ab96ed6b06250f84bb5d040a07456b44c47c8ccefddff0",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "lib/runmain.o",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "388e300176266d67824db54b2c53676e46f8b9df9c59d636b8791b096d742e9e",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    },
+    {
+      "path": "share/man/man1/tcc.1",
+      "kind": "file",
+      "git_mode": "100644",
+      "sha256": "89a72bd3a03f021ea5a6d3e1ec93998606c8e4d5a2fdbb9a4c3f3b098073b4f0",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "legacy-bundle-payload",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "outputs": [
+    {
+      "path": "tcc.exe",
+      "kind": "executable",
+      "git_mode": "100755",
+      "sha256": "d9004cf0549674194eae79237b7f8100c3658c3897fd0d2b672d47dd340a3151",
+      "symlink_target": null,
+      "provenance": {
+        "status": "incomplete",
+        "repository": null,
+        "sha": null,
+        "source_path": null,
+        "license": null
+      },
+      "role": "native-compiler",
+      "opaque": false,
+      "opaque_acceptance_id": null,
+      "format": null,
+      "object_type": null,
+      "machine": null,
+      "os_abi": null
+    }
+  ],
+  "probes": [
+    {
+      "id": "manifest-contract",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "strict schema, binding, and semantic validation"
+    },
+    {
+      "id": "source-provenance",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "unresolved sources remain explicitly non-publishable"
+    },
+    {
+      "id": "native-build",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "native build succeeds"
+    },
+    {
+      "id": "payload-inventory",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "manifest inventory is expanded before eligibility"
+    },
+    {
+      "id": "patch-probes",
+      "required": true,
+      "expected_lanes": [],
+      "oracle": "empty patchset materializes one expected-zero result"
+    },
+    {
+      "id": "tccbin-conformance",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "shared conformance passes"
+    },
+    {
+      "id": "v-no-fallback-smoke",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "V uses the selected compiler without fallback"
+    },
+    {
+      "id": "artifact-digests",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "declared output digests match"
+    },
+    {
+      "id": "publish-preflight-dry-run",
+      "required": true,
+      "expected_lanes": [
+        "x64"
+      ],
+      "oracle": "publish remains false"
+    }
+  ],
+  "provenance_status": "incomplete",
+  "affected_targets": [
+    "macos-amd64"
+  ]
+}

--- a/automation/probes/baseline-contract.sh
+++ b/automation/probes/baseline-contract.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+IFS=$'\n\t'
+export LC_ALL=C
+
+readonly expected_contract_repository='vlang/v'
+
+if [[ $# -ne 8 ]]; then
+	printf '%s\n' 'usage: baseline-contract.sh <validator> <contract-root> <bundle-root> <target-id> <canonical-branch> <contract-sha> <bundle-sha> <vc-root>' >&2
+	exit 2
+fi
+
+validator=$1
+contract_root=$2
+bundle_root=$3
+target_id=$4
+canonical_branch=$5
+expected_contract_sha=$6
+bundle_sha=$7
+vc_root=$8
+manifest="$bundle_root/automation/bundle-manifest.json"
+schema="$contract_root/thirdparty/tccbin_automation/schemas/bundle-manifest.schema.json"
+
+[[ -x "$validator" && -d "$contract_root" && -d "$bundle_root" && -d "$vc_root" ]] || exit 1
+[[ -f "$manifest" && ! -L "$manifest" && -f "$schema" && ! -L "$schema" ]] || exit 1
+[[ "$expected_contract_sha" =~ ^[0-9a-f]{40}$ && "$bundle_sha" =~ ^[0-9a-f]{40}$ ]] || exit 1
+
+validator_command() {
+	(cd -P -- "$contract_root" && "$validator" "$@")
+}
+
+case "${PUBLISH:-false}:${TCCBIN_PUBLISH:-false}" in
+	false:false | 0:0 | false:0 | 0:false) ;;
+	*) printf '%s\n' 'baseline contract probe refuses publication' >&2; exit 1 ;;
+esac
+
+binding=$(validator_command contract-binding)
+[[ "$binding" == "repository=$expected_contract_repository sha=$expected_contract_sha" ]] || {
+	printf '%s\n' 'validator contract binding mismatch' >&2
+	exit 1
+}
+
+validator_command contract >/dev/null
+[[ "$(validator_command validate "$schema" "$manifest")" == 'valid' ]]
+canonical=$(validator_command canonicalize "$manifest")
+
+for exact_member in \
+	"\"contract_repository\":\"$expected_contract_repository\"" \
+	"\"contract_sha\":\"$expected_contract_sha\"" \
+	'"contract_mode":"production"' \
+	"\"v_source_sha\":\"$expected_contract_sha\"" \
+	"\"target_id\":\"$target_id\"" \
+	"\"branch\":\"$canonical_branch\"" \
+	'"provenance_status":"incomplete"'; do
+	case "$canonical" in
+		*"$exact_member"*) ;;
+		*) printf '%s\n' 'manifest baseline binding mismatch' >&2; exit 1 ;;
+	esac
+done
+
+fingerprints=$(validator_command fingerprint "$manifest")
+[[ $(printf '%s\n' "$fingerprints" | wc -l | tr -d ' ') == 3 ]]
+for key in manifest_hash input_fingerprint artifact_fingerprint; do
+	value=$(printf '%s\n' "$fingerprints" | sed -n "s/^${key}=//p")
+	[[ "$value" =~ ^[0-9a-f]{64}$ ]]
+done
+
+[[ "$(git -C "$bundle_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$bundle_root" rev-parse HEAD)" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" rev-parse --verify "${bundle_sha}^{commit}")" == "$bundle_sha" ]]
+[[ "$(git -C "$bundle_root" symbolic-ref -q HEAD || true)" == '' ]]
+[[ "$(git -C "$bundle_root" status --porcelain=v1 --untracked-files=all --ignored=matching)" == '' ]]
+
+staging_parent=${RUNNER_TEMP:-${TMPDIR:-/tmp}}
+staging_root=$(mktemp -d "$staging_parent/tccbin-payload.XXXXXX")
+cleanup_paths=("$staging_root")
+linked_bundle=false
+for generated_v in v1 v2 v v1.exe v2.exe v.exe; do
+	[[ ! -e "$contract_root/$generated_v" && ! -L "$contract_root/$generated_v" ]]
+done
+cleanup() {
+	status=$?
+	trap - EXIT HUP INT TERM
+	if [[ "$linked_bundle" == true ]]; then
+		rm -rf -- "$contract_root/thirdparty/tcc"
+	fi
+	rm -f -- "$contract_root/v1" "$contract_root/v2" "$contract_root/v" \
+		"$contract_root/v1.exe" "$contract_root/v2.exe" "$contract_root/v.exe"
+	for cleanup_path in "${cleanup_paths[@]}"; do
+		[[ -n "$cleanup_path" && -d "$cleanup_path" ]] && rm -rf -- "$cleanup_path"
+	done
+	exit "$status"
+}
+trap cleanup EXIT HUP INT TERM
+
+git -C "$bundle_root" archive --format=tar "$bundle_sha" | tar -xf - -C "$staging_root"
+rm -rf -- "$staging_root/.github" "$staging_root/automation"
+case "$target_id" in
+	windows-amd64)
+		rm -f -- \
+			"$staging_root/build.ps1" \
+			"$staging_root/0001-tccpe-strip-quotes-and-default-.dll-extension-in-DEF.patch" \
+			"$staging_root/0002-win32-don-t-treat-DBG_PRINTEXCEPTION_C-as-a-fatal-cr.patch" \
+			"$staging_root/0003-win32-declare-CreateSymbolicLink.patch" \
+			"$staging_root/0004-win32-declare-WSAConnectBy-family.patch" \
+			"$staging_root/0005-win32-declare-InetNtop-InetPton-family.patch" \
+			"$staging_root/0006-win32-declare-shell-drag-drop-family.patch" \
+			"$staging_root/0007-win32-declare-secure-narrow-stdio.patch" \
+			"$staging_root/0008-win32-fix-exp2-range-reduction.patch" \
+			"$staging_root/0009-win32-declare-CancelIoEx.patch" \
+			"$staging_root/vlang-header-compat.patch" \
+			"$staging_root/v-ae88ee5-tinycc-bdwgc.patch"
+		;;
+	linux-amd64 | macos-amd64 | macos-arm64 | freebsd-amd64 | openbsd-amd64)
+		rm -f -- "$staging_root/build.sh"
+		;;
+	*) printf '%s\n' 'unknown target for payload staging' >&2; exit 1 ;;
+esac
+
+staged_result=$(validator_command staged-preflight \
+	"$manifest" "$staging_root" "$bundle_root" "$bundle_sha" false)
+readonly expected_staged_result='eligible=false reason=staged_provenance_incomplete publish_allowed=false manifest_hash= input_fingerprint= artifact_fingerprint='
+[[ "$staged_result" == "$expected_staged_result" ]] || {
+	printf 'unexpected staged preflight result: %s\n' "$staged_result" >&2
+	exit 1
+}
+
+[[ "$(git -C "$contract_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$vc_root" config --get core.autocrlf)" == false ]]
+[[ "$(git -C "$contract_root" rev-parse HEAD)" == "$expected_contract_sha" ]]
+vc_sha=$(sed -n 's/^commit=//p' "$contract_root/thirdparty/tccbin_automation/bootstrap/vc.lock")
+[[ "$vc_sha" =~ ^[0-9a-f]{40}$ && "$(git -C "$vc_root" rev-parse HEAD)" == "$vc_sha" ]]
+
+contract_tcc="$contract_root/thirdparty/tcc"
+if [[ -e "$contract_tcc" || -L "$contract_tcc" ]]; then
+	[[ "$(cd -P -- "$contract_tcc" && pwd)" == "$(cd -P -- "$bundle_root" && pwd)" ]]
+else
+	ln -s "$bundle_root" "$contract_tcc"
+	linked_bundle=true
+fi
+
+case "$target_id" in
+	windows-amd64)
+		cc_name=${CC:-gcc}
+		exe_suffix=.exe
+		;;
+	*)
+		cc_name=${CC:-cc}
+		exe_suffix=
+		;;
+esac
+cc_path=$(command -v -- "$cc_name")
+[[ "$cc_path" == /* && -x "$cc_path" ]]
+
+if [[ "$target_id" == windows-amd64 ]]; then
+	"$cc_path" -std=c99 -municode -w -o "$contract_root/v1.exe" "$vc_root/v_win.c" \
+		-ladvapi32 -lws2_32 -Wl,-stack=33554432
+	(
+		cd -P -- "$contract_root"
+		./v1.exe -no-parallel -nocache -cc "$cc_path" -o ./v2.exe -gc none cmd/v
+		./v2.exe -no-parallel -nocache -cc "$cc_path" -o ./v.exe -gc none cmd/v
+	)
+else
+	link_flags=(-lm -lpthread)
+	case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			link_flags+=(-lexecinfo)
+			;;
+	esac
+	"$cc_path" -std=c99 -w -o "$contract_root/v1" "$vc_root/v.c" "${link_flags[@]}"
+	(
+		cd -P -- "$contract_root"
+		case "$target_id" in
+		freebsd-amd64 | openbsd-amd64)
+			./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none \
+				-ldflags -lexecinfo cmd/v
+			./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none \
+				-ldflags -lexecinfo cmd/v
+			;;
+		*)
+			./v1 -no-parallel -nocache -cc "$cc_path" -o ./v2 -gc none cmd/v
+			./v2 -no-parallel -nocache -cc "$cc_path" -o ./v -gc none cmd/v
+			;;
+		esac
+	)
+fi
+
+smoke_root=$(mktemp -d "$staging_parent/tccbin-v-smoke.XXXXXX")
+cleanup_paths+=("$smoke_root")
+cat > "$smoke_root/main.v" <<'VEOF'
+module main
+
+fn main() {
+	println('tccbin-v-smoke')
+}
+VEOF
+smoke_binary="$smoke_root/tccbin-v-smoke${exe_suffix}"
+if ! showcc_output=$(
+	cd -P -- "$contract_root"
+	"./v${exe_suffix}" -cc tcc -gc none -showcc -no-retry-compilation -no-rsp \
+		-o "$smoke_binary" "$smoke_root/main.v" 2>&1
+); then
+	printf '%s\n' "$showcc_output" >&2
+	exit 1
+fi
+printf '%s\n' "$showcc_output"
+if printf '%s\n' "$showcc_output" | grep -Eiq \
+	'falling back to|retrying with|fallback compiler|backup compiler'; then
+	printf '%s\n' 'V attempted a compiler fallback' >&2
+	exit 1
+fi
+normalized_showcc=$(printf '%s\n' "$showcc_output" | tr '\\' '/')
+case "$normalized_showcc" in
+	*'/thirdparty/tcc/tcc.exe'*) ;;
+	*) printf '%s\n' 'V did not report the bundled tcc.exe command' >&2; exit 1 ;;
+esac
+[[ -f "$smoke_binary" ]]
+[[ "$($smoke_binary)" == 'tccbin-v-smoke' ]]
+
+printf 'tccbin baseline contract target=%s staged=incomplete smoke=v-tcc publish=false: PASS\n' "$target_id"


### PR DESCRIPTION
## Summary

This PR adds the Phase A read-only automation baseline for the macOS AMD64 tccbin bundle and binds it to the merged `vlang/v` automation contract.

It adds an immutable bundle manifest, contract and provenance validation, a no-fallback V smoke test, and the existing native conformance checks behind a single branch gate.

## Why

The goal is to make future tccbin updates reproducible and auditable, while rejecting stale, incomplete, or unverified candidates before they can reach a publication path.

## Safety

This PR does not enable publication. Provenance remains incomplete, `PUBLISH` and `TCCBIN_PUBLISH` stay disabled, and the workflow has no secrets, artifact uploads, or Git push capability.